### PR TITLE
Fix gpu related settings schema desync from ts types

### DIFF
--- a/packages/lms-shared-types/src/embedding/EmbeddingLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/embedding/EmbeddingLoadModelConfig.ts
@@ -14,7 +14,7 @@ export interface EmbeddingLoadModelConfig {
   tryMmap?: boolean;
 }
 export const embeddingLoadModelConfigSchema = z.object({
-  gpuOffload: gpuSettingSchema.optional(),
+  gpu: gpuSettingSchema.optional(),
   contextLength: z.number().int().min(1).optional(),
   ropeFrequencyBase: z.number().optional(),
   ropeFrequencyScale: z.number().optional(),

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -233,7 +233,7 @@ export interface LLMLoadModelConfig {
   llamaVCacheQuantizationType?: LLMLlamaCacheQuantizationType | false;
 }
 export const llmLoadModelConfigSchema = z.object({
-  gpuOffload: gpuSettingSchema.optional(),
+  gpu: gpuSettingSchema.optional(),
   contextLength: z.number().int().min(1).optional(),
   ropeFrequencyBase: z.number().optional(),
   ropeFrequencyScale: z.number().optional(),


### PR DESCRIPTION
It was working because of another bug: https://github.com/lmstudio-ai/lmstudio-js/pull/257