### PR TITLE
GPUSplitConfig

### DIFF
--- a/packages/lms-client/src/embedding/EmbeddingNamespace.ts
+++ b/packages/lms-client/src/embedding/EmbeddingNamespace.ts
@@ -2,7 +2,7 @@ import { type SimpleLogger, type Validator } from "@lmstudio/lms-common";
 import { type EmbeddingPort } from "@lmstudio/lms-external-backend-interfaces";
 import { embeddingLlamaLoadConfigSchematics } from "@lmstudio/lms-kv-config";
 import {
-  convertGPUSettingToGPUSplitStrategy,
+  convertGPUSettingToGPUSplitConfig,
   embeddingLoadModelConfigSchema,
   type EmbeddingLoadModelConfig,
   type EmbeddingModelInfo,
@@ -35,7 +35,7 @@ export class EmbeddingNamespace extends ModelNamespace<
   protected override loadConfigToKVConfig(config: EmbeddingLoadModelConfig): KVConfig {
     return embeddingLlamaLoadConfigSchematics.buildPartialConfig({
       "llama.acceleration.offloadRatio": config.gpu?.ratio,
-      "load.gpuSplitStrategy": convertGPUSettingToGPUSplitStrategy(config.gpu),
+      "load.gpuSplitConfig": convertGPUSettingToGPUSplitConfig(config.gpu),
       "contextLength": config.contextLength,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-client/src/embedding/EmbeddingNamespace.ts
+++ b/packages/lms-client/src/embedding/EmbeddingNamespace.ts
@@ -2,6 +2,7 @@ import { type SimpleLogger, type Validator } from "@lmstudio/lms-common";
 import { type EmbeddingPort } from "@lmstudio/lms-external-backend-interfaces";
 import { embeddingLlamaLoadConfigSchematics } from "@lmstudio/lms-kv-config";
 import {
+  convertGPUSettingToGPUSplitStrategy,
   embeddingLoadModelConfigSchema,
   type EmbeddingLoadModelConfig,
   type EmbeddingModelInfo,
@@ -34,9 +35,7 @@ export class EmbeddingNamespace extends ModelNamespace<
   protected override loadConfigToKVConfig(config: EmbeddingLoadModelConfig): KVConfig {
     return embeddingLlamaLoadConfigSchematics.buildPartialConfig({
       "llama.acceleration.offloadRatio": config.gpu?.ratio,
-      "load.mainGpu": config.gpu?.mainGpu,
-      "load.splitStrategy": config.gpu?.splitStrategy,
-      "load.disabledGpus": config.gpu?.disabledGpus,
+      "load.gpuSplitStrategy": convertGPUSettingToGPUSplitStrategy(config.gpu),
       "contextLength": config.contextLength,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -2,7 +2,7 @@ import { type SimpleLogger, type Validator } from "@lmstudio/lms-common";
 import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
 import { llmLlamaMoeLoadConfigSchematics } from "@lmstudio/lms-kv-config";
 import {
-  convertGPUSettingToGPUSplitStrategy,
+  convertGPUSettingToGPUSplitConfig,
   llmLoadModelConfigSchema,
   type KVConfig,
   type LLMInfo,
@@ -38,7 +38,7 @@ export class LLMNamespace extends ModelNamespace<
       "contextLength": config.contextLength,
       "llama.evalBatchSize": config.evalBatchSize,
       "llama.acceleration.offloadRatio": config.gpu?.ratio,
-      "load.gpuSplitStrategy": convertGPUSettingToGPUSplitStrategy(config.gpu),
+      "load.gpuSplitConfig": convertGPUSettingToGPUSplitConfig(config.gpu),
       "llama.flashAttention": config.flashAttention,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -2,6 +2,7 @@ import { type SimpleLogger, type Validator } from "@lmstudio/lms-common";
 import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
 import { llmLlamaMoeLoadConfigSchematics } from "@lmstudio/lms-kv-config";
 import {
+  convertGPUSettingToGPUSplitStrategy,
   llmLoadModelConfigSchema,
   type KVConfig,
   type LLMInfo,
@@ -37,9 +38,7 @@ export class LLMNamespace extends ModelNamespace<
       "contextLength": config.contextLength,
       "llama.evalBatchSize": config.evalBatchSize,
       "llama.acceleration.offloadRatio": config.gpu?.ratio,
-      "load.mainGpu": config.gpu?.mainGpu,
-      "load.splitStrategy": config.gpu?.splitStrategy,
-      "load.disabledGpus": config.gpu?.disabledGpus,
+      "load.gpuSplitStrategy": convertGPUSettingToGPUSplitStrategy(config.gpu),
       "llama.flashAttention": config.flashAttention,
       "llama.ropeFrequencyBase": numberToCheckboxNumeric(config.ropeFrequencyBase, 0, 0),
       "llama.ropeFrequencyScale": numberToCheckboxNumeric(config.ropeFrequencyScale, 0, 0),

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -291,11 +291,12 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
       ),
   )
   .scope("load", builder =>
-    builder
-      .field("disabledGpus", "numericArray", { machineDependent: true, min: 0, int: true }, [])
-      .field("mainGpu", "mainGpu", { machineDependent: true }, 0)
-      .field("tensorSplit", "tensorSplit", { machineDependent: true }, [0])
-      .field("splitStrategy", "gpuSplitStrategy", {}, "evenly"),
+    builder.field(
+      "gpuSplitStrategy",
+      "gpuSplitStrategy",
+      {},
+      { type: "evenly", disabledGpus: [], priority: [] },
+    ),
   )
   .scope("embedding.load", builder =>
     builder

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -292,10 +292,10 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
   )
   .scope("load", builder =>
     builder.field(
-      "gpuSplitStrategy",
-      "gpuSplitStrategy",
+      "gpuSplitConfig",
+      "gpuSplitConfig",
       {},
-      { type: "evenly", disabledGpus: [], priority: [] },
+      { strategy: "evenly", disabledGpus: [], priority: [] },
     ),
   )
   .scope("embedding.load", builder =>

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -1,6 +1,6 @@
 import {
   allowableEnvVarsSchema,
-  gpuSplitStrategySchema,
+  gpuSplitConfigSchema,
   kvConfigFieldDependencySchema,
   llmContextOverflowPolicySchema,
   llmContextReferenceSchema,
@@ -660,10 +660,10 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
       return JSON.stringify(value, null, 2);
     },
   })
-  .valueType("gpuSplitStrategy", {
+  .valueType("gpuSplitConfig", {
     paramType: {},
     schemaMaker: () => {
-      return gpuSplitStrategySchema;
+      return gpuSplitConfigSchema;
     },
     effectiveEquals: (a, b) => {
       return deepEquals(a, b);

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -1,5 +1,6 @@
 import {
   allowableEnvVarsSchema,
+  gpuSplitStrategySchema,
   kvConfigFieldDependencySchema,
   llmContextOverflowPolicySchema,
   llmContextReferenceSchema,
@@ -10,7 +11,6 @@ import {
   llmMlxKvCacheQuantizationSchema,
   llmPromptTemplateSchema,
   llmReasoningParsingSchema,
-  llmSplitStrategySchema,
   llmStructuredPredictionSettingSchema,
   llmToolUseSettingSchema,
   modelDomainTypeSchema,
@@ -568,47 +568,6 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
       return (value * 100).toFixed(0) + "%";
     },
   })
-  .valueType("mainGpu", {
-    paramType: {},
-    schemaMaker: () => {
-      return z.number().int().nonnegative();
-    },
-    effectiveEquals: (a, b) => {
-      return a === b;
-    },
-    stringify: value => {
-      return String(value); // TODO: Show GPU name
-    },
-  })
-  .valueType("tensorSplit", {
-    paramType: {},
-    schemaMaker: () => {
-      return z.array(z.number().nonnegative());
-    },
-    effectiveEquals: (a, b) => {
-      return deepEquals(a, b); // TODO: more performant comparison
-    },
-    stringify: value => {
-      return value.join(", "); // TODO: Better display
-    },
-  })
-  .valueType("gpuSplitStrategy", {
-    paramType: {},
-    schemaMaker: () => {
-      return llmSplitStrategySchema;
-    },
-    effectiveEquals: (a, b) => {
-      return a === b;
-    },
-    stringify: (value, _typeParam, { t }) => {
-      switch (value) {
-        case "evenly":
-          return t("config:customInputs.gpuSplitStrategy.evenly", "Evenly");
-        case "favorMainGpu":
-          return t("config:customInputs.gpuSplitStrategy.favorMainGpu", "Favor Main GPU");
-      }
-    },
-  })
   .valueType("llamaMirostatSampling", {
     paramType: {},
     schemaMaker: () => {
@@ -693,6 +652,18 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
     paramType: {},
     schemaMaker: () => {
       return allowableEnvVarsSchema;
+    },
+    effectiveEquals: (a, b) => {
+      return deepEquals(a, b);
+    },
+    stringify: value => {
+      return JSON.stringify(value, null, 2);
+    },
+  })
+  .valueType("gpuSplitStrategy", {
+    paramType: {},
+    schemaMaker: () => {
+      return gpuSplitStrategySchema;
     },
     effectiveEquals: (a, b) => {
       return deepEquals(a, b);

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { type GPUSetting } from ".";
 
-export type GPUSplitStrategy = "evenly" | "priorityOrder";
-export const gpuSplitStrategySchema = z.enum(["evenly", "priorityOrder"]);
+export const gpuSplitStrategies = ["evenly", "priorityOrder"] as const;
+export type GPUSplitStrategy = (typeof gpuSplitStrategies)[number];
+export const gpuSplitStrategySchema = z.enum(gpuSplitStrategies);
 
 /**
  * Settings related to splitting work across multiple GPUs.

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
 import { type GPUSetting } from ".";
 
-export type GPUSplitStrategyType = "evenly" | "priorityOrder";
-export const gpuSplitStrategyTypeSchema = z.enum(["evenly", "priorityOrder"]);
+export type GPUSplitStrategy = "evenly" | "priorityOrder";
+export const gpuSplitStrategySchema = z.enum(["evenly", "priorityOrder"]);
 
 /**
  * Settings related to splitting work across multiple GPUs.
@@ -11,11 +11,11 @@ export const gpuSplitStrategyTypeSchema = z.enum(["evenly", "priorityOrder"]);
  *
  * @public
  */
-export type GPUSplitStrategy = {
+export type GPUSplitConfig = {
   /**
    * Different modalities for splitting work across multiple GPUs.
    */
-  type: GPUSplitStrategyType;
+  strategy: GPUSplitStrategy;
   /**
    * Indices of GPUs to disable.
    */
@@ -25,15 +25,15 @@ export type GPUSplitStrategy = {
    */
   priority: number[];
 };
-export const gpuSplitStrategySchema = z.object({
-  type: gpuSplitStrategyTypeSchema,
+export const gpuSplitConfigSchema = z.object({
+  strategy: gpuSplitStrategySchema,
   disabledGpus: z.array(z.number().int().min(0)),
   priority: z.array(z.number().int().min(0)),
 });
 
-export function convertGPUSettingToGPUSplitStrategy(gpuSetting?: GPUSetting): GPUSplitStrategy {
+export function convertGPUSettingToGPUSplitConfig(gpuSetting?: GPUSetting): GPUSplitConfig {
   return {
-    type:
+    strategy:
       gpuSetting?.splitStrategy == "favorMainGpu"
         ? "priorityOrder"
         : gpuSetting?.splitStrategy ?? "evenly",

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { type GPUSetting } from ".";
+
+export type GPUSplitStrategyType = "evenly" | "priorityOrder";
+export const gpuSplitStrategyTypeSchema = z.enum(["evenly", "priorityOrder"]);
+
+/**
+ * Settings related to splitting work across multiple GPUs.
+ *
+ * Not currently exposed through the SDK, deduced from GPUSetting.
+ *
+ * @public
+ */
+export type GPUSplitStrategy = {
+  /**
+   * Different modalities for splitting work across multiple GPUs.
+   */
+  type: GPUSplitStrategyType;
+  /**
+   * Indices of GPUs to disable.
+   */
+  disabledGpus: number[];
+  /**
+   * GPU indices in order of priority.
+   */
+  priority: number[];
+};
+export const gpuSplitStrategySchema = z.object({
+  type: gpuSplitStrategyTypeSchema,
+  disabledGpus: z.array(z.number().int().min(0)),
+  priority: z.array(z.number().int().min(0)),
+});
+
+export function convertGPUSettingToGPUSplitStrategy(gpuSetting?: GPUSetting): GPUSplitStrategy {
+  return {
+    type:
+      gpuSetting?.splitStrategy == "favorMainGpu"
+        ? "priorityOrder"
+        : gpuSetting?.splitStrategy ?? "evenly",
+    disabledGpus: gpuSetting?.disabledGpus ?? [],
+    priority: gpuSetting?.mainGpu ? [gpuSetting.mainGpu] : [],
+  };
+}

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -82,10 +82,10 @@ export {
 export { FileType, fileTypeSchema } from "./files/FileType.js";
 export {
   convertGPUSettingToGPUSplitConfig as convertGPUSettingToGPUSplitConfig,
+  GPUSplitConfig,
   gpuSplitConfigSchema,
-  GPUSplitConfig as GPUSplitStrategy,
-  GPUSplitStrategy as GPUSplitStrategyType,
-  gpuSplitStrategySchema as gpuSplitStrategyTypeSchema,
+  GPUSplitStrategy,
+  gpuSplitStrategySchema,
 } from "./GPUSplitStrategy.js";
 export {
   KVConfig,

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -81,6 +81,13 @@ export {
 } from "./files/FileIdentifier.js";
 export { FileType, fileTypeSchema } from "./files/FileType.js";
 export {
+  convertGPUSettingToGPUSplitStrategy,
+  GPUSplitStrategy,
+  gpuSplitStrategySchema,
+  GPUSplitStrategyType,
+  gpuSplitStrategyTypeSchema,
+} from "./GPUSplitStrategy.js";
+export {
   KVConfig,
   KVConfigField,
   KVConfigFieldDependency,

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -81,7 +81,7 @@ export {
 } from "./files/FileIdentifier.js";
 export { FileType, fileTypeSchema } from "./files/FileType.js";
 export {
-  convertGPUSettingToGPUSplitConfig as convertGPUSettingToGPUSplitConfig,
+  convertGPUSettingToGPUSplitConfig,
   GPUSplitConfig,
   gpuSplitConfigSchema,
   GPUSplitStrategy,

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -81,11 +81,11 @@ export {
 } from "./files/FileIdentifier.js";
 export { FileType, fileTypeSchema } from "./files/FileType.js";
 export {
-  convertGPUSettingToGPUSplitStrategy,
-  GPUSplitStrategy,
-  gpuSplitStrategySchema,
-  GPUSplitStrategyType,
-  gpuSplitStrategyTypeSchema,
+  convertGPUSettingToGPUSplitConfig as convertGPUSettingToGPUSplitConfig,
+  gpuSplitConfigSchema,
+  GPUSplitConfig as GPUSplitStrategy,
+  GPUSplitStrategy as GPUSplitStrategyType,
+  gpuSplitStrategySchema as gpuSplitStrategyTypeSchema,
 } from "./GPUSplitStrategy.js";
 export {
   KVConfig,

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -84,6 +84,7 @@ export {
   convertGPUSettingToGPUSplitConfig,
   GPUSplitConfig,
   gpuSplitConfigSchema,
+  gpuSplitStrategies,
   GPUSplitStrategy,
   gpuSplitStrategySchema,
 } from "./GPUSplitStrategy.js";


### PR DESCRIPTION
Creates a new composite value type that called `GPUSplitConfig` that contains:
1. `strategy` - A split strategy enum `evenly` or `priorityOrder`
2. `disabledGpus` - array of gpu indices to disable
3. `priority` - array of gpu indices in priority order

This will be the future of setting how to split models between multiple gpus.

To not make a breaking change, in the API we still use `GPUSetting`, and just convert `GPUSetting` to this new `GPUSplitConfig` when converting it to KV.

Removes `mainGpu` from KV, as this will be set by `priority`

