### PR TITLE
Add custom ratio to GPUSplitStrategy

### DIFF
--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -25,7 +25,7 @@ export type GPUSplitConfig = {
    */
   strategy: GPUSplitStrategy;
   /**
-   * Indices of GPUs to disable. Used when strategy is "custom" or "priorityOrder".
+   * Indices of GPUs to disable. Not used when strategy is "custom".
    */
   disabledGpus: number[];
   /**

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { type GPUSetting } from ".";
 
-export const gpuSplitStrategies = ["evenly", "priorityOrder"] as const;
+export const gpuSplitStrategies = ["evenly", "priorityOrder", "custom"] as const;
 export type GPUSplitStrategy = (typeof gpuSplitStrategies)[number];
 export const gpuSplitStrategySchema = z.enum(gpuSplitStrategies);
 
@@ -9,6 +9,7 @@ export const defaultGPUSplitConfig: GPUSplitConfig = {
   strategy: "evenly",
   disabledGpus: [],
   priority: [],
+  customRatio: [],
 };
 
 /**
@@ -31,11 +32,16 @@ export type GPUSplitConfig = {
    * GPU indices in order of priority.
    */
   priority: number[];
+  /**
+   * Ratio array to assign how to split offloading between GPUs. Used if strategy is "custom".
+   */
+  customRatio: number[];
 };
 export const gpuSplitConfigSchema = z.object({
   strategy: gpuSplitStrategySchema,
   disabledGpus: z.array(z.number().int().min(0)),
   priority: z.array(z.number().int().min(0)),
+  customRatio: z.array(z.number().min(0)),
 });
 
 export function convertGPUSettingToGPUSplitConfig(gpuSetting?: GPUSetting): GPUSplitConfig {
@@ -46,5 +52,6 @@ export function convertGPUSettingToGPUSplitConfig(gpuSetting?: GPUSetting): GPUS
         : gpuSetting?.splitStrategy ?? "evenly",
     disabledGpus: gpuSetting?.disabledGpus ?? [],
     priority: gpuSetting?.mainGpu ? [gpuSetting.mainGpu] : [],
+    customRatio: [],
   };
 }

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -25,15 +25,21 @@ export type GPUSplitConfig = {
    */
   strategy: GPUSplitStrategy;
   /**
-   * Indices of GPUs to disable.
+   * Indices of GPUs to disable. Used when strategy is "custom" or "priorityOrder".
    */
   disabledGpus: number[];
   /**
-   * GPU indices in order of priority.
+   * GPU indices in order of priority for offloading. Only used when strategy is "priorityOrder".
    */
   priority: number[];
   /**
-   * Ratio array to assign how to split offloading between GPUs. Used if strategy is "custom".
+   * Ratio array to assign how to split offloading between GPUs. Only used when strategy is
+   * "custom", and if so ignores disabledGpus and priority.
+   *
+   * Examples:
+   * [5, 2.5, 2,5] - 50% of model offload on GPU 0, 25% on GPU 1, 25% on GPU 2
+   * [1, 1, 1] - Model evenly offloaded on all GPUs
+   * [1, 0, 0] - Model offloaded only onto GPU 0
    */
   customRatio: number[];
 };


### PR DESCRIPTION
Essentially synonymous to tensor_split as exposed by llama.cpp, high granularity split strategy option.