### PR TITLE
Specifying presets in SDK

### DIFF
--- a/packages/lms-client/src/friendlyErrorDeserializer.ts
+++ b/packages/lms-client/src/friendlyErrorDeserializer.ts
@@ -193,6 +193,40 @@ registerErrorDeserializer(
   },
 );
 
+function formatAvailablePresets(
+  presets: Array<{ identifier: string; name: string }>,
+  totalAvailablePresets: number,
+) {
+  if (presets.length === 0) {
+    return chalk.gray("    You don't have any presets available.");
+  }
+  let text = presets
+    .map(({ identifier, name }) => chalk.cyanBright(` • ${name} (${chalk.cyan(identifier)})`))
+    .join("\n");
+  if (presets.length < totalAvailablePresets) {
+    text += chalk.gray(`\n     ... (and ${totalAvailablePresets - presets.length} more)`);
+  }
+  return text;
+}
+
+registerErrorDeserializer(
+  "generic.presetNotFound",
+  ({ specifiedFuzzyPresetIdentifier, availablePresetsSample, totalAvailablePresets }) => {
+    return makeTitledPrettyError(
+      `Cannot find a preset with identifier "${chalk.yellowBright(specifiedFuzzyPresetIdentifier)}"`,
+      text`
+        Here are your available presets:
+
+        ${formatAvailablePresets(availablePresetsSample, totalAvailablePresets)}
+
+        Note: To specify a preset in the SDK, you need to use its identifier (in parentheses). You
+        can get a preset's identifier by right-clicking on it and then select "Copy Preset
+        Identifier".
+      `,
+    );
+  },
+);
+
 export function friendlyErrorDeserializer(
   serialized: SerializedLMSExtendedError,
   _directCause: string,

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -83,8 +83,8 @@ export interface LLMPredictionOpts<TStructuredOutputType = unknown>
    * @remarks
    *
    * This preset selection is "layered" between your overrides and the "server session" config.
-   * Which means, other fields you specify in this opts object will override the preset, while the preset content
-   * will override the "server session" config.
+   * Which means, other fields you specify in this opts object will override the preset, while the
+   * preset content will override the "server session" config.
    */
   preset?: string;
 }
@@ -330,8 +330,8 @@ export interface LLMActionOpts<TStructuredOutputType = unknown>
    * @remarks
    *
    * This preset selection is "layered" between your overrides and the "server session" config.
-   * Which means, other fields you specify in this opts object will override the preset, while the preset content
-   * will override the "server session" config.
+   * Which means, other fields you specify in this opts object will override the preset, while the
+   * preset content will override the "server session" config.
    */
   preset?: string;
 }

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -83,7 +83,7 @@ export interface LLMPredictionOpts<TStructuredOutputType = unknown>
    * @remarks
    *
    * This preset selection is "layered" between your overrides and the "server session" config.
-   * Which means, other fields you specify here will override the preset, while the preset content
+   * Which means, other fields you specify in this opts object will override the preset, while the preset content
    * will override the "server session" config.
    */
   preset?: string;
@@ -330,7 +330,7 @@ export interface LLMActionOpts<TStructuredOutputType = unknown>
    * @remarks
    *
    * This preset selection is "layered" between your overrides and the "server session" config.
-   * Which means, other fields you specify here will override the preset, while the preset content
+   * Which means, other fields you specify in this opts object will override the preset, while the preset content
    * will override the "server session" config.
    */
   preset?: string;

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -77,12 +77,23 @@ export interface LLMPredictionOpts<TStructuredOutputType = unknown>
    * An abort signal that can be used to cancel the prediction.
    */
   signal?: AbortSignal;
+  /**
+   * Which preset to use.
+   *
+   * @remarks
+   *
+   * This preset selection is "layered" between your overrides and the "server session" config.
+   * Which means, other fields you specify here will override the preset, while the preset content
+   * will override the "server session" config.
+   */
+  preset?: string;
 }
 const llmPredictionOptsSchema = llmPredictionConfigInputSchema.extend({
   onPromptProcessingProgress: z.function().optional(),
   onFirstToken: z.function().optional(),
   onPredictionFragment: z.function().optional(),
   signal: z.instanceof(AbortSignal).optional(),
+  preset: z.string().optional(),
 });
 
 type LLMPredictionExtraOpts<TStructuredOutputType = unknown> = Omit<
@@ -96,9 +107,18 @@ function splitPredictionOpts<TStructuredOutputType>(
   LLMPredictionConfigInput<TStructuredOutputType>,
   LLMPredictionExtraOpts<TStructuredOutputType>,
 ] {
-  const { onPromptProcessingProgress, onFirstToken, onPredictionFragment, signal, ...config } =
-    opts;
-  return [config, { onPromptProcessingProgress, onFirstToken, onPredictionFragment, signal }];
+  const {
+    onPromptProcessingProgress,
+    onFirstToken,
+    onPredictionFragment,
+    signal,
+    preset,
+    ...config
+  } = opts;
+  return [
+    config,
+    { onPromptProcessingProgress, onFirstToken, onPredictionFragment, signal, preset },
+  ];
 }
 
 /**
@@ -304,6 +324,16 @@ export interface LLMActionOpts<TStructuredOutputType = unknown>
    * An abort signal that can be used to cancel the prediction.
    */
   signal?: AbortSignal;
+  /**
+   * Which preset to use.
+   *
+   * @remarks
+   *
+   * This preset selection is "layered" between your overrides and the "server session" config.
+   * Which means, other fields you specify here will override the preset, while the preset content
+   * will override the "server session" config.
+   */
+  preset?: string;
 }
 const llmActionOptsSchema = llmPredictionConfigInputSchema.extend({
   onFirstToken: z.function().optional(),
@@ -315,6 +345,8 @@ const llmActionOptsSchema = llmPredictionConfigInputSchema.extend({
   onPromptProcessingProgress: z.function().optional(),
   handleInvalidToolRequest: z.function().optional(),
   maxPredictionRounds: z.number().int().min(1).optional(),
+  signal: z.instanceof(AbortSignal).optional(),
+  preset: z.string().optional(),
 });
 
 const defaultHandleInvalidToolRequest = (error: Error, request: ToolCallRequest | undefined) => {
@@ -342,6 +374,8 @@ function splitOperationOpts<TStructuredOutputType>(
     onPromptProcessingProgress,
     handleInvalidToolRequest,
     maxPredictionRounds,
+    signal,
+    preset,
     ...config
   } = opts;
   return [
@@ -356,6 +390,8 @@ function splitOperationOpts<TStructuredOutputType>(
       onPromptProcessingProgress,
       handleInvalidToolRequest,
       maxPredictionRounds,
+      signal,
+      preset,
     },
   ];
 }
@@ -436,6 +472,7 @@ export class LLMDynamicHandle extends DynamicHandle<
         modelSpecifier: this.specifier,
         history,
         predictionConfigStack,
+        fuzzyPresetIdentifier: extraOpts.preset,
         ignoreServerSessionConfig: this.internalIgnoreServerSessionConfig,
       },
       message => {
@@ -969,6 +1006,7 @@ export class LLMDynamicHandle extends DynamicHandle<
           modelSpecifier: this.specifier,
           history: accessMaybeMutableInternals(mutableChat)._internalGetData(),
           predictionConfigStack: configToUse,
+          fuzzyPresetIdentifier: extraOpts.preset,
           ignoreServerSessionConfig: this.internalIgnoreServerSessionConfig,
         },
         message => {

--- a/packages/lms-common/src/makePrettyError.ts
+++ b/packages/lms-common/src/makePrettyError.ts
@@ -5,7 +5,7 @@ import process from "process";
 import { changeErrorStackInPlace } from "./errorStack.js";
 
 export function makeTitledPrettyError(title: string, content: string, stack?: string) {
-  return makePrettyError(chalk.redBright(` ${title} `) + "\n\n" + content, stack);
+  return makePrettyError(chalk.redBright(title) + "\n\n" + content, stack);
 }
 export function makePrettyError(content: string, stack?: string): Error {
   if ((process as any).browser || process.env.LMS_NO_FANCY_ERRORS || terminalSize().columns < 80) {

--- a/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/llmBackendInterface.ts
@@ -31,6 +31,10 @@ export function createLlmBackendInterface() {
           modelSpecifier: modelSpecifierSchema,
           history: chatHistoryDataSchema,
           predictionConfigStack: kvConfigStackSchema,
+          /**
+           * Which preset to use. Supports limited fuzzy matching.
+           */
+          fuzzyPresetIdentifier: z.string().optional(),
           ignoreServerSessionConfig: z.boolean().optional(),
         }),
         toClientPacket: z.discriminatedUnion("type", [

--- a/packages/lms-shared-types/src/GenericErrorDisplayData.ts
+++ b/packages/lms-shared-types/src/GenericErrorDisplayData.ts
@@ -37,6 +37,15 @@ export type GenericErrorDisplayData =
       engineType: string;
       installedVersion: string;
       supportedVersion: string | null;
+    }
+  | {
+      code: "generic.presetNotFound";
+      specifiedFuzzyPresetIdentifier: string;
+      availablePresetsSample: Array<{
+        identifier: string;
+        name: string;
+      }>;
+      totalAvailablePresets: number;
     };
 export const genericErrorDisplayDataSchema = [
   z.object({
@@ -73,5 +82,16 @@ export const genericErrorDisplayDataSchema = [
     engineType: z.string(),
     installedVersion: z.string(),
     supportedVersion: z.string().nullable(),
+  }),
+  z.object({
+    code: z.literal("generic.presetNotFound"),
+    specifiedFuzzyPresetIdentifier: z.string(),
+    availablePresetsSample: z.array(
+      z.object({
+        identifier: z.string(),
+        name: z.string(),
+      }),
+    ),
+    totalAvailablePresets: z.number().int(),
   }),
 ] as const;

--- a/packages/lms-shared-types/src/KVConfig.ts
+++ b/packages/lms-shared-types/src/KVConfig.ts
@@ -37,6 +37,8 @@ export type KVConfigLayerName =
   | "conversationSpecific"
   // Cross-chat global config in chats
   | "conversationGlobal"
+  // Per-request preset selection
+  | "preset"
   // Server session specific config
   | "serverSession"
   // Override provided in the OpenAI http server
@@ -60,6 +62,7 @@ export const kvConfigLayerNameSchema = z.enum([
   "apiOverride",
   "conversationSpecific",
   "conversationGlobal",
+  "preset",
   "serverSession",
   "httpServerRequestOverride",
   "completeModeFormatting",

--- a/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionConfig.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z, type ZodSchema } from "zod";
 import { zodSchemaSchema } from "../Zod.js";
 import { llmPromptTemplateSchema, type LLMPromptTemplate } from "./LLMPromptTemplate.js";
 import {
@@ -297,12 +297,13 @@ export const llmPredictionConfigInputSchema = z.object({
 /**
  * @public
  */
-export interface LLMPredictionConfig extends LLMPredictionConfigInput<any> {
+export type LLMPredictionConfig = Omit<LLMPredictionConfigInput<any>, "structured"> & {
   structured?: LLMStructuredPredictionSetting;
-}
-export const llmPredictionConfigSchema = llmPredictionConfigInputSchema.extend({
+};
+export const llmPredictionConfigSchema = z.object({
+  ...llmPredictionConfigInputSchema.shape,
   structured: llmStructuredPredictionSettingSchema.optional(),
-});
+}) as ZodSchema<LLMPredictionConfig>;
 
 export interface LLMLlamaMirostatSamplingConfig {
   /**


### PR DESCRIPTION
Allow specifying presets in SDK for .respond, .complete, and .act.

Unfortunately no test coverage at the moment due to no easy way to make sure testing environment having the desired preset.