### PR TITLE
Fix generation finish earlier than intended, cutting off the last couple tokens,

### DIFF
--- a/packages/lms-common/src/StreamablePromise.ts
+++ b/packages/lms-common/src/StreamablePromise.ts
@@ -139,7 +139,7 @@ export abstract class StreamablePromise<TFragment, TFinal>
       this.hasIterator = true;
     }
     let i = 0;
-    while (this.status === "pending") {
+    while (i < this.buffer.length || this.status === "pending") {
       if (i < this.buffer.length) {
         yield this.buffer[i];
         i++;


### PR DESCRIPTION
The previous logic stops the iteration as soon as the prediction ends. However, there might still be fragments in the buffer that has not been read yet. This makes sure that the iterator finishes the buffer.