### PR TITLE
Remove stmux

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "process": "^0.11.10",
         "rollup": "^4.27.4",
         "shx": "^0.3.4",
-        "stmux": "^1.8.7",
         "tailwindcss": "^3.4.1",
         "ts-loader": "^9.5.1",
         "typescript": "^5.7.3"
@@ -1438,17 +1437,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.21.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.13.11"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -9136,11 +9124,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/abab": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/abbrev": {
       "version": "2.0.0",
       "license": "ISC",
@@ -9160,50 +9143,12 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-globals": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn": "^8.1.0",
-        "acorn-walk": "^8.0.2"
-      }
-    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-node": {
-      "version": "1.8.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "acorn": "^7.0.0",
-        "acorn-walk": "^7.0.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn": {
-      "version": "7.4.1",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-node/node_modules/acorn-walk": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -9250,11 +9195,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/aggregation": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ajv": {
       "version": "6.12.6",
@@ -9422,11 +9362,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "dev": true,
@@ -9542,14 +9477,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/asty": {
-      "version": "1.8.18",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/async": {
@@ -9872,32 +9799,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/blessed": {
-      "version": "0.1.81",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "blessed": "bin/tput.js"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/blessed-xterm": {
-      "version": "1.4.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "blessed": "0.1.81",
-        "clone": "2.1.2",
-        "jsdom": "21.1.1",
-        "node-pty": "0.10.1",
-        "xterm": "2.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/boolean": {
@@ -10364,11 +10265,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/chownr": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/chrome-trace-event": {
       "version": "1.0.3",
       "dev": true,
@@ -10457,14 +10353,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-deep": {
@@ -10624,20 +10512,6 @@
       "version": "0.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/concat-stream": {
-      "version": "1.6.2",
-      "dev": true,
-      "engines": [
-        "node >= 0.8"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
@@ -10858,50 +10732,12 @@
         "node": ">=4"
       }
     },
-    "node_modules/cssstyle": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rrweb-cssom": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/d": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "es5-ext": "^0.10.50",
-        "type": "^1.0.1"
-      }
-    },
     "node_modules/dargs": {
       "version": "7.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dash-ast": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/data-urls": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/data-view-buffer": {
@@ -11013,11 +10849,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/decimal.js": {
-      "version": "10.4.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "dev": true,
@@ -11045,14 +10876,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -11231,17 +11054,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/domexception": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "dev": true,
@@ -11299,14 +11111,6 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/duplexer2": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "readable-stream": "^2.0.2"
-      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -11576,78 +11380,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/es5-ext": {
-      "version": "0.10.62",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "es6-iterator": "^2.0.3",
-        "es6-symbol": "^3.1.3",
-        "next-tick": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
     "node_modules/es6-error": {
       "version": "4.1.1",
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/es6-iterator": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "^0.10.35",
-        "es6-symbol": "^3.1.1"
-      }
-    },
-    "node_modules/es6-map": {
-      "version": "0.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-set": "~0.1.5",
-        "es6-symbol": "~3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
-    "node_modules/es6-set": {
-      "version": "0.1.6",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "es5-ext": "^0.10.62",
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "^3.1.3",
-        "event-emitter": "^0.3.5",
-        "type": "^2.7.2"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "node_modules/es6-set/node_modules/type": {
-      "version": "2.7.2",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/es6-symbol": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      }
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -11668,26 +11405,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/escodegen": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^5.2.0",
-        "esutils": "^2.0.2"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -12025,11 +11742,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/estree-is-function": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -12043,15 +11755,6 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/event-emitter": {
-      "version": "0.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "d": "1",
-        "es5-ext": "~0.10.14"
       }
     },
     "node_modules/eventemitter3": {
@@ -12102,14 +11805,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "dev": true,
@@ -12128,19 +11823,6 @@
     "node_modules/exponential-backoff": {
       "version": "3.1.1",
       "license": "Apache-2.0"
-    },
-    "node_modules/ext": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "type": "^2.7.2"
-      }
-    },
-    "node_modules/ext/node_modules/type": {
-      "version": "2.7.2",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -12596,11 +12278,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/get-assigned-identifiers": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "dev": true,
@@ -12833,11 +12510,6 @@
         "ini": "^1.3.2"
       }
     },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/glob": {
       "version": "7.2.3",
       "dev": true,
@@ -13011,7 +12683,9 @@
     "node_modules/growly": {
       "version": "1.3.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/handlebars": {
       "version": "4.7.8",
@@ -13039,14 +12713,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/has": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/has-bigints": {
@@ -13150,17 +12816,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/html-encoding-sniffer": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-encoding": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/html-escaper": {
@@ -13844,11 +13499,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "1.2.1",
@@ -16734,50 +16384,6 @@
       "version": "1.1.0",
       "license": "MIT"
     },
-    "node_modules/jsdom": {
-      "version": "21.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.2",
-        "acorn-globals": "^7.0.0",
-        "cssstyle": "^3.0.0",
-        "data-urls": "^4.0.0",
-        "decimal.js": "^10.4.3",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.2",
-        "rrweb-cssom": "^0.6.0",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^12.0.1",
-        "ws": "^8.13.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -17626,14 +17232,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.1"
-      }
-    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "dev": true,
@@ -17882,22 +17480,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/merge-source-map": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "^0.5.6"
-      }
-    },
-    "node_modules/merge-source-map/node_modules/source-map": {
-      "version": "0.5.7",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/merge-stream": {
@@ -18156,11 +17738,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/modify-values": {
       "version": "1.0.1",
       "dev": true,
@@ -18238,11 +17815,6 @@
         "thenify-all": "^1.0.0"
       }
     },
-    "node_modules/nan": {
-      "version": "2.18.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
       "version": "3.3.7",
       "dev": true,
@@ -18259,11 +17831,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -18283,22 +17850,6 @@
       "version": "2.6.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/next-tick": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/node-abi": {
-      "version": "3.54.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -18426,6 +17977,8 @@
       "version": "10.0.1",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -18433,17 +17986,6 @@
         "shellwords": "^0.1.1",
         "uuid": "^8.3.2",
         "which": "^2.0.2"
-      }
-    },
-    "node_modules/node-pty": {
-      "name": "@homebridge/node-pty-prebuilt-multiarch",
-      "version": "0.11.12",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "nan": "^2.18.0",
-        "prebuild-install": "^7.1.1"
       }
     },
     "node_modules/node-releases": {
@@ -18952,11 +18494,6 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
-    },
-    "node_modules/nwsapi": {
-      "version": "2.2.7",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nx": {
       "version": "18.0.4",
@@ -19869,28 +19406,6 @@
         "parse-path": "^7.0.0"
       }
     },
-    "node_modules/parse5": {
-      "version": "7.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/parse5/node_modules/entities": {
-      "version": "4.5.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/patch-package": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
@@ -20038,36 +19553,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pegjs": {
-      "version": "0.10.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "pegjs": "bin/pegjs"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/pegjs-otf": {
-      "version": "1.2.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "4.17.21",
-        "pegjs": "0.10.0",
-        "static-module": "3.0.4",
-        "through": "2.3.8"
-      }
-    },
-    "node_modules/pegjs-util": {
-      "version": "1.4.21",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pegjs": ">=0.10.0"
       }
     },
     "node_modules/pend": {
@@ -20470,39 +19955,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "dev": true,
@@ -20716,11 +20168,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -20761,11 +20208,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/querystringify": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "funding": [
@@ -20802,28 +20244,6 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react-is": {
@@ -21205,11 +20625,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz",
@@ -21236,11 +20651,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/requires-port": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -21441,11 +20851,6 @@
         "sourcemap-codec": "^1.4.8"
       }
     },
-    "node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/run-async": {
       "version": "3.0.0",
       "dev": true,
@@ -21528,7 +20933,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -21569,17 +20975,6 @@
       "version": "2.1.2",
       "license": "MIT"
     },
-    "node_modules/saxes": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "xmlchars": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=v12.22.7"
-      }
-    },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "dev": true,
@@ -21596,20 +20991,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/scope-analyzer": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "array-from": "^2.1.1",
-        "dash-ast": "^2.0.1",
-        "es6-map": "^0.1.5",
-        "es6-set": "^0.1.5",
-        "es6-symbol": "^3.1.1",
-        "estree-is-function": "^1.0.0",
-        "get-assigned-identifiers": "^1.1.0"
       }
     },
     "node_modules/semver": {
@@ -21730,11 +21111,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shallow-copy": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "license": "MIT",
@@ -21771,7 +21147,9 @@
     "node_modules/shellwords": {
       "version": "0.1.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/shx": {
       "version": "0.3.4",
@@ -22016,49 +21394,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -22274,182 +21609,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/static-eval": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "escodegen": "^2.1.0"
-      }
-    },
-    "node_modules/static-module": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "acorn-node": "^1.3.0",
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "^1.11.1",
-        "has": "^1.0.1",
-        "magic-string": "0.25.1",
-        "merge-source-map": "1.0.4",
-        "object-inspect": "^1.6.0",
-        "readable-stream": "~2.3.3",
-        "scope-analyzer": "^2.0.1",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.5",
-        "through2": "~2.0.3"
-      }
-    },
-    "node_modules/static-module/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/static-module/node_modules/escodegen": {
-      "version": "1.14.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esprima": "^4.0.1",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
-      },
-      "bin": {
-        "escodegen": "bin/escodegen.js",
-        "esgenerate": "bin/esgenerate.js"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "optionalDependencies": {
-        "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/static-module/node_modules/estraverse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/static-module/node_modules/levn": {
-      "version": "0.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-module/node_modules/optionator": {
-      "version": "0.8.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.6",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "word-wrap": "~1.2.3"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-module/node_modules/prelude-ls": {
-      "version": "1.1.2",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/static-module/node_modules/type-check": {
-      "version": "0.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "~1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/stmux": {
-      "version": "1.8.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "7.21.0",
-        "aggregation": "1.2.7",
-        "asty": "1.8.18",
-        "blessed": "0.1.81",
-        "blessed-xterm": "1.4.6",
-        "chalk": "4.1.2",
-        "node-notifier": "10.0.1",
-        "pegjs-otf": "1.2.20",
-        "pegjs-util": "1.4.21",
-        "strip-ansi": "6.0.0",
-        "which": "3.0.0",
-        "yargs": "17.7.1"
-      },
-      "bin": {
-        "stmux": "bin/stmux.js"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/stmux/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/stmux/node_modules/which": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/which.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/stmux/node_modules/yargs": {
-      "version": "17.7.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/string_decoder": {
@@ -22742,11 +21901,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/symbol-tree": {
-      "version": "3.2.4",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/synckit": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -22821,17 +21975,6 @@
       },
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
       }
     },
     "node_modules/tar-stream": {
@@ -23143,31 +22286,6 @@
         "node": "*"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "4.1.3",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/tr46": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "punycode": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/treeverse": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/treeverse/-/treeverse-3.0.0.tgz",
@@ -23440,22 +22558,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/type": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "ISC"
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "dev": true,
@@ -23660,14 +22762,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/universalify": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/upath": {
       "version": "2.0.1",
       "dev": true,
@@ -23723,15 +22817,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/url-parse": {
-      "version": "1.5.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "querystringify": "^2.1.1",
-        "requires-port": "^1.0.0"
-      }
-    },
     "node_modules/utf-8-validate": {
       "version": "5.0.10",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
@@ -23767,6 +22852,8 @@
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -23818,17 +22905,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/w3c-xmlserializer": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/walk-up-path": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/walk-up-path/-/walk-up-path-3.0.1.tgz",
@@ -23863,14 +22939,6 @@
       "license": "MIT",
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/webpack": {
@@ -23950,48 +23018,6 @@
       "peer": true,
       "engines": {
         "node": ">=4.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/whatwg-mimetype": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "12.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "^4.1.1",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/which": {
@@ -24113,14 +23139,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/word-wrap": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/wordwrap": {
@@ -24285,19 +23303,6 @@
         }
       }
     },
-    "node_modules/xml-name-validator": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/xmlchars": {
-      "version": "2.2.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "dev": true,
@@ -24305,11 +23310,6 @@
       "engines": {
         "node": ">=0.4"
       }
-    },
-    "node_modules/xterm": {
-      "version": "2.8.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "process": "^0.11.10",
     "rollup": "^4.27.4",
     "shx": "^0.3.4",
-    "stmux": "^1.8.7",
     "tailwindcss": "^3.4.1",
     "ts-loader": "^9.5.1",
     "typescript": "^5.7.3"


### PR DESCRIPTION
stmux does not work on windows arm

This technically breaks the npm start command, but few people are using it. And If you are indeed using it, you can install stmux globally.