### PR TITLE
[LLMJinjaInputConfig] useTools -> toolUseType

### DIFF
--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -405,7 +405,7 @@ const noFormattingInputConfig: LLMJinjaInputConfig = {
       type: "string",
     },
   },
-  useTools: false,
+  toolUseType: "noTools",
 };
 
 /**

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -187,6 +187,8 @@ export {
   llmJinjaInputMessagesContentConfigTextFieldNameSchema,
   LLMJinjaInputMessagesContentImagesConfig,
   llmJinjaInputMessagesContentImagesConfigSchema,
+  LLMJinjaInputToolUseType,
+  llmJinjaInputToolUseTypeSchema,
   LLMJinjaPromptTemplate,
   llmJinjaPromptTemplateSchema,
   LLMManualPromptTemplate,

--- a/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
+++ b/packages/lms-shared-types/src/llm/LLMPromptTemplate.ts
@@ -117,6 +117,17 @@ export const llmJinjaInputMessagesContentConfigSchema = z.discriminatedUnion("ty
 ]);
 
 /**
+ * Configures how tools should be input to jinja for prompt rendering.
+ * @public
+ */
+export type LLMJinjaInputToolUseType = "noTools" | "inSystemMessage" | "inToolsField";
+export const llmJinjaInputToolUseTypeSchema = z.enum([
+  "noTools",
+  "inSystemMessage",
+  "inToolsField",
+]);
+
+/**
  * Configures how ChatHistoryMessages should be input to jinja for prompt rendering.
  * @public
  */
@@ -135,11 +146,11 @@ export const llmJinjaInputMessagesConfigSchema = z.object({
  */
 export interface LLMJinjaInputConfig {
   messagesConfig: LLMJinjaInputMessagesConfig;
-  useTools: boolean;
+  toolUseType: LLMJinjaInputToolUseType;
 }
 export const llmJinjaInputConfigSchema = z.object({
   messagesConfig: llmJinjaInputMessagesConfigSchema,
-  useTools: z.boolean(),
+  toolUseType: llmJinjaInputToolUseTypeSchema,
 });
 
 /**

--- a/publish/sdk/src/exportedTypes.ts
+++ b/publish/sdk/src/exportedTypes.ts
@@ -114,6 +114,7 @@ export type {
   LLMJinjaInputMessagesContentConfig,
   LLMJinjaInputMessagesContentConfigTextFieldName,
   LLMJinjaInputMessagesContentImagesConfig,
+  LLMJinjaInputToolUseType,
   LLMJinjaPromptTemplate,
   LLMLlamaAccelerationOffloadRatio,
   LLMLlamaCacheQuantizationType,


### PR DESCRIPTION
This allows our jinja tool use resolution to be more flexible, for models like phi-4-mini that expect tools to be added to a special `tools` field in the system message for jinja rendering. See https://huggingface.co/microsoft/Phi-4-mini-instruct#tool-enabled-function-calling-format.