### PR TITLE
[MLX] Add top-k sampling support

### DIFF
--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -43,6 +43,11 @@ export function kvConfigToLLMPredictionConfig(config: KVConfig) {
   const topKSampling = parsed.get("llm.prediction.topKSampling");
   if (topKSampling !== undefined) {
     result.topKSampling = topKSampling;
+  } else {
+    const mlxTopKSampling = parsed.get("llm.prediction.mlx.topKSampling");
+    if (mlxTopKSampling !== undefined && mlxTopKSampling.checked) {
+      result.topKSampling = mlxTopKSampling.value;
+    }
   }
 
   const repeatPenalty = parsed.get("llm.prediction.repeatPenalty");
@@ -131,6 +136,7 @@ export function llmPredictionConfigToKVConfig(config: LLMPredictionConfig): KVCo
     "structured": config.structured,
     "tools": config.rawTools,
     "topKSampling": config.topKSampling,
+    "mlx.topKSampling": maybeFalseNumberToCheckboxNumeric(config.topKSampling, 10),
     "repeatPenalty": maybeFalseNumberToCheckboxNumeric(config.repeatPenalty, 1.1),
     "minPSampling": maybeFalseNumberToCheckboxNumeric(config.minPSampling, 0.05),
     "topPSampling": maybeFalseNumberToCheckboxNumeric(config.topPSampling, 0.95),

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -217,6 +217,14 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
             { checked: false, value: 0.9 },
           )
           .field("logitBias", "llamaLogitBias", {}, []),
+      )
+      .scope("mlx", builder =>
+        builder.field(
+          "topKSampling",
+          "checkboxNumeric",
+          { min: 1, max: 1000 },
+          { checked: false, value: 40 },
+        ),
       ),
   )
   .scope("llm.load", builder =>


### PR DESCRIPTION
Add back MLX top-k support and address comment https://github.com/lmstudio-ai/lmstudio-js/pull/192#discussion_r2017414072 that got this feature previously reverted

Ref https://github.com/lmstudio-ai/mlx-engine/issues/59