### PR TITLE
Add offloadKVCacheToGpu to load parameters

### DIFF
--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -295,7 +295,8 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
   .scope("load", builder =>
     builder
       .field("gpuSplitConfig", "gpuSplitConfig", {}, defaultGPUSplitConfig)
-      .field("gpuStrictVramCap", "boolean", {}, false),
+      .field("gpuStrictVramCap", "boolean", {}, false)
+      .field("noKvOffload", "boolean", {}, false),
   )
   .scope("embedding.load", builder =>
     builder

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -296,7 +296,7 @@ export const globalConfigSchematics = new KVConfigSchematicsBuilder(kvValueTypes
     builder
       .field("gpuSplitConfig", "gpuSplitConfig", {}, defaultGPUSplitConfig)
       .field("gpuStrictVramCap", "boolean", {}, false)
-      .field("noKvOffload", "boolean", {}, false),
+      .field("offloadKVCacheToGpu", "boolean", {}, true),
   )
   .scope("embedding.load", builder =>
     builder

--- a/packages/lms-kv-config/src/valueTypes.ts
+++ b/packages/lms-kv-config/src/valueTypes.ts
@@ -69,6 +69,11 @@ export const kvValueTypesLibrary = new KVFieldValueTypesLibraryBuilder({
    */
   nonConfigurable: z.boolean().optional(),
   /**
+   * A field can be marked as engineDoesNotSupport when when the engine running the model does not
+   * support the field.
+   */
+  engineDoesNotSupport: z.boolean().optional(),
+  /**
    * A field can be marked as machine dependent when its value is highly dependent on the machine
    * that is being used. When exporting the config, one may decide to not include machine dependent
    * fields by default.

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -131,7 +131,7 @@ export interface LLMLoadModelConfig {
   gpuStrictVramCap?: boolean;
 
   /**
-   * If set to true, KV cache will not be offloaded to GPU memory.
+   * If set to true, KV cache will be offloaded to RAM instead of GPU memory.
    *
    * @public
    */

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -131,11 +131,12 @@ export interface LLMLoadModelConfig {
   gpuStrictVramCap?: boolean;
 
   /**
-   * If set to true, KV cache will be offloaded to RAM instead of GPU memory.
+   * If set to true, KV cache will be offloaded to GPU memory if available. If false, KV cache will
+   * be loaded to RAM.
    *
    * @public
    */
-  noKvOffload?: boolean;
+  offloadKVCacheToGpu?: boolean;
 
   /**
    * The size of the context length in number of tokens. This will include both the prompts and the
@@ -257,7 +258,7 @@ export interface LLMLoadModelConfig {
 export const llmLoadModelConfigSchema = z.object({
   gpu: gpuSettingSchema.optional(),
   gpuStrictVramCap: z.boolean().optional(),
-  noKvOffload: z.boolean().optional(),
+  offloadKVCacheToGpu: z.boolean().optional(),
   contextLength: z.number().int().min(1).optional(),
   ropeFrequencyBase: z.number().optional(),
   ropeFrequencyScale: z.number().optional(),

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -131,6 +131,13 @@ export interface LLMLoadModelConfig {
   gpuStrictVramCap?: boolean;
 
   /**
+   * If set to true, KV Cache will not be offloaded to GPU memory.
+   *
+   * @public
+   */
+  noKvOffload?: boolean;
+
+  /**
    * The size of the context length in number of tokens. This will include both the prompts and the
    * responses. Once the context length is exceeded, the value set in
    * {@link LLMPredictionConfigBase#contextOverflowPolicy} is used to determine the behavior.
@@ -250,6 +257,7 @@ export interface LLMLoadModelConfig {
 export const llmLoadModelConfigSchema = z.object({
   gpu: gpuSettingSchema.optional(),
   gpuStrictVramCap: z.boolean().optional(),
+  noKvOffload: z.boolean().optional(),
   contextLength: z.number().int().min(1).optional(),
   ropeFrequencyBase: z.number().optional(),
   ropeFrequencyScale: z.number().optional(),

--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -131,7 +131,7 @@ export interface LLMLoadModelConfig {
   gpuStrictVramCap?: boolean;
 
   /**
-   * If set to true, KV Cache will not be offloaded to GPU memory.
+   * If set to true, KV cache will not be offloaded to GPU memory.
    *
    * @public
    */


### PR DESCRIPTION
For llama.cpp parameter https://github.com/ggml-org/llama.cpp/blob/b34c859146630dff136943abc9852ca173a7c9d6/common/common.h#L332

Allows you to put KV cache in RAM instead of VRAM