### PR TITLE
Add mcp bridge plugin type

### DIFF
--- a/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
+++ b/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
@@ -14,6 +14,7 @@ export class ToolsProviderController {
   public constructor(
     public readonly client: LMStudioClient,
     private readonly pluginConfig: KVConfig,
+    public readonly signal: AbortSignal,
   ) {}
 
   public getPluginConfig<TVirtualConfigSchematics extends VirtualConfigSchematics>(

--- a/packages/lms-shared-types/src/PluginManifest.ts
+++ b/packages/lms-shared-types/src/PluginManifest.ts
@@ -4,8 +4,8 @@ import { artifactManifestBaseSchema, type ArtifactManifestBase } from "./Artifac
 /**
  * @public
  */
-export type PluginRunnerType = "ecmascript";
-export const pluginRunnerTypeSchema = z.enum(["ecmascript"]);
+export type PluginRunnerType = "ecmascript" | "mcpBridge";
+export const pluginRunnerTypeSchema = z.enum(["ecmascript", "mcpBridge"]);
 
 /**
  * @public


### PR DESCRIPTION
Adds a new plugin type called mcpBridge, which is used internally to run MCPs as regular plugins.