### PR TITLE
Flexible es plugin install

### DIFF
--- a/packages/lms-client/src/repository/RepositoryNamespace.ts
+++ b/packages/lms-client/src/repository/RepositoryNamespace.ts
@@ -58,6 +58,16 @@ export interface PushArtifactOpts {
    */
   description?: string;
   /**
+   * Request to make the artifact private. Only effective if the artifact did not exist before. Will
+   * not change the visibility of an existing artifact.
+   */
+  makePrivate?: boolean;
+  /**
+   * If true, will write the revision number of the artifact after the push back to the artifact
+   * manifest.json.
+   */
+  writeRevision?: boolean;
+  /**
    * Internal overrides for updating artifact metadata.
    */
   overrides?: any;
@@ -66,6 +76,8 @@ export interface PushArtifactOpts {
 export const pushArtifactOptsSchema = z.object({
   path: z.string(),
   description: z.string().optional(),
+  makePrivate: z.boolean().optional(),
+  writeRevision: z.boolean().optional(),
   overrides: jsonSerializableSchema.optional(),
   onMessage: z.function().optional(),
 }) as ZodSchema<PushArtifactOpts>;
@@ -225,17 +237,18 @@ export class RepositoryNamespace {
    */
   public async pushArtifact(opts: PushArtifactOpts): Promise<void> {
     const stack = getCurrentStack(1);
-    const { path, description, overrides, onMessage } = this.validator.validateMethodParamOrThrow(
-      "repository",
-      "pushArtifact",
-      "opts",
-      pushArtifactOptsSchema,
-      opts,
-      stack,
-    );
+    const { path, description, makePrivate, writeRevision, overrides, onMessage } =
+      this.validator.validateMethodParamOrThrow(
+        "repository",
+        "pushArtifact",
+        "opts",
+        pushArtifactOptsSchema,
+        opts,
+        stack,
+      );
     const channel = this.repositoryPort.createChannel(
       "pushArtifact",
-      { path, description, overrides },
+      { path, description, makePrivate, writeRevision, overrides },
       message => {
         const type = message.type;
         switch (type) {

--- a/packages/lms-es-plugin-runner/src/EsPluginInstaller.ts
+++ b/packages/lms-es-plugin-runner/src/EsPluginInstaller.ts
@@ -7,7 +7,18 @@ import { generateEntryFile } from "./generateEntryFile.js";
 import { UtilBinary } from "./UtilBinary.js";
 
 export interface EsPluginInstallerInstallOpts {
+  /**
+   * Only installs dependencies. Does not build the plugins.
+   */
   dependenciesOnly?: boolean;
+  /**
+   * Do not install dependencies, only create the entry file and build the plugin.
+   */
+  skipDependencies?: boolean;
+  /**
+   * If provided, uses the util binary from this folder instead.
+   */
+  utilsFolderPathOverride?: string;
   npmRegistry?: string;
   logger?: SimpleLogger;
 }
@@ -39,25 +50,29 @@ export class EsPluginInstaller {
     pluginPath: string,
     {
       dependenciesOnly = false,
+      skipDependencies = false,
+      utilsFolderPathOverride,
       npmRegistry,
       logger = new SimpleLogger("EsPluginInstaller"),
     }: EsPluginInstallerInstallOpts = {},
   ) {
-    const arb = new Arborist({
-      path: pluginPath,
-      registry: npmRegistry,
-      ignoreScripts: true,
-    });
-    logger.info(`Installing dependencies in ${pluginPath}...`);
-    await arb.reify();
-    const cacheFolderPath = join(pluginPath, ".lmstudio");
+    if (!skipDependencies) {
+      const arb = new Arborist({
+        path: pluginPath,
+        registry: npmRegistry,
+        ignoreScripts: true,
+      });
+      logger.info(`Installing dependencies in ${pluginPath}...`);
+      await arb.reify();
+    }
     if (dependenciesOnly) {
       return;
     }
+    const cacheFolderPath = join(pluginPath, ".lmstudio");
     logger.info(`Creating entry file in ${cacheFolderPath}...`);
     const entryFilePath = await this.createEntryFile(cacheFolderPath);
     const args = await this.createEsBuildArgs(cacheFolderPath, entryFilePath);
-    const esbuild = new UtilBinary("esbuild");
+    const esbuild = new UtilBinary("esbuild", { utilsFolderPathOverride });
     logger.info(`Building plugin with esbuild...`);
     await esbuild.check();
     await esbuild.exec(args);

--- a/packages/lms-es-plugin-runner/src/UtilBinary.ts
+++ b/packages/lms-es-plugin-runner/src/UtilBinary.ts
@@ -4,15 +4,21 @@ import { spawn, type SpawnOptionsWithoutStdio } from "child_process";
 import { access } from "fs/promises";
 import { join } from "path";
 
+export interface UtilBinaryOpts {
+  /**
+   * If provided, uses the util binary from this folder instead.
+   */
+  utilsFolderPathOverride?: string;
+}
+
 export class UtilBinary {
   private readonly path: string;
-  public constructor(private readonly name: string) {
-    this.path = join(
-      findLMStudioHome(),
-      ".internal",
-      "utils",
-      process.platform === "win32" ? `${name}.exe` : name,
-    );
+  public constructor(
+    private readonly name: string,
+    { utilsFolderPathOverride }: UtilBinaryOpts = {},
+  ) {
+    const utilsFolder = utilsFolderPathOverride ?? join(findLMStudioHome(), ".internal", "utils");
+    this.path = join(utilsFolder, process.platform === "win32" ? `${name}.exe` : name);
   }
   public async check() {
     try {

--- a/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
@@ -106,6 +106,16 @@ export function createRepositoryBackendInterface() {
         creationParameter: z.object({
           path: z.string(),
           description: z.string().max(1000).optional(),
+          /**
+           * Request to make the artifact private. Only effective if the artifact did not exist
+           * before. Will not change the visibility of an existing artifact.
+           */
+          makePrivate: z.boolean().optional(),
+          /**
+           * If true, will write the revision number of the artifact after the push back to the
+           * artifact manifest.json.
+           */
+          writeRevision: z.boolean().optional(),
           overrides: jsonSerializableSchema.optional(),
         }),
         toServerPacket: z.void(),

--- a/packages/lms-isomorphic/.npmignore
+++ b/packages/lms-isomorphic/.npmignore
@@ -1,0 +1,1 @@
+*.tsbuildinfo

--- a/packages/lms-shared-types/src/ModelInfoBase.ts
+++ b/packages/lms-shared-types/src/ModelInfoBase.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import {
   modelCompatibilityTypeSchema,
   type ModelCompatibilityType,
-} from "./ModelCompatibilityType";
+} from "./ModelCompatibilityType.js";
 
 /**
  * Represents info of a model that is downloaded and sits on the disk. This is the base type shared

--- a/packages/lms-shared-types/src/PluginManifest.ts
+++ b/packages/lms-shared-types/src/PluginManifest.ts
@@ -4,8 +4,8 @@ import { artifactManifestBaseSchema, type ArtifactManifestBase } from "./Artifac
 /**
  * @public
  */
-export type PluginRunnerType = "ecmascript" | "mcpBridge";
-export const pluginRunnerTypeSchema = z.enum(["ecmascript", "mcpBridge"]);
+export type PluginRunnerType = "ecmascript" | "node" | "mcpBridge";
+export const pluginRunnerTypeSchema = z.enum(["ecmascript", "node", "mcpBridge"]);
 
 /**
  * @public

--- a/packages/lms-shared-types/src/llm/ContentBlockStyle.ts
+++ b/packages/lms-shared-types/src/llm/ContentBlockStyle.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { colorPaletteSchema, type ColorPalette } from "../ColorPalette";
+import { colorPaletteSchema, type ColorPalette } from "../ColorPalette.js";
 
 /**
  * The style of a content block.


### PR DESCRIPTION
Depends on https://github.com/lmstudio-ai/lms/pull/239

- Make esplugin installer also take in "skipDependencies" to not install dependencies
- Make esplugin installer also take in "utilsFolderPathOverride" to change the location of the utils folder path so it can be used in machines where LM Studio is not installed yet
- Added support for flags in https://github.com/lmstudio-ai/lms/pull/239
- Fixed a couple imports (missing .js suffix, breaking es module support)
- Rename "ecmascript" runner to "node"