### PR TITLE
Add support for global config

### DIFF
--- a/packages/lms-client/src/PluginContext.ts
+++ b/packages/lms-client/src/PluginContext.ts
@@ -9,11 +9,20 @@ import { type ToolsProvider } from "./plugins/processing/ToolsProvider.js";
  */
 export interface PluginContext {
   /**
-   * Sets the config schematics associated with this plugin context. Returns the same PluginContext
-   * for chaining.
+   * Sets the local config schematics associated with this plugin context. Local configs are per
+   * chat, useful for configurations that would affect context. Returns the same PluginContext for
+   * chaining.
    */
   withConfigSchematics: (
     configSchematics: ConfigSchematics<VirtualConfigSchematics>,
+  ) => PluginContext;
+  /**
+   * Sets the global config schematics associated with this plugin context. Global configs are
+   * global across the entire application, useful for things like API keys or database
+   * configurations. Returns the same PluginContext for chaining.
+   */
+  withGlobalConfigSchematics: (
+    globalConfigSchematics: ConfigSchematics<VirtualConfigSchematics>,
   ) => PluginContext;
   /**
    * Sets the prediction loop handler associated with this plugin context. Returns the same

--- a/packages/lms-client/src/plugins/PluginsNamespace.ts
+++ b/packages/lms-client/src/plugins/PluginsNamespace.ts
@@ -263,6 +263,7 @@ export class PluginsNamespace {
               connector,
               message.config,
               message.pluginConfig,
+              message.globalPluginConfig,
               /* shouldIncludeInputInHistory */ false,
               message.workingDirectoryPath,
             );
@@ -394,6 +395,7 @@ export class PluginsNamespace {
               connector,
               message.config,
               message.pluginConfig,
+              message.globalPluginConfig,
               /* shouldIncludeInputInHistory */ true,
               message.workingDirectoryPath,
             );
@@ -447,6 +449,7 @@ export class PluginsNamespace {
       { stack },
     );
   }
+
   /**
    * @deprecated Plugin support is still in development. Stay tuned for updates.
    */
@@ -467,6 +470,32 @@ export class PluginsNamespace {
       {
         schematics: (
           configSchematics as KVConfigSchematics<GlobalKVFieldValueTypeLibraryMap, any>
+        ).serialize(),
+      },
+      { stack },
+    );
+  }
+
+  /**
+   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   */
+  public async setGlobalConfigSchematics(globalConfigSchematics: ConfigSchematics<any>) {
+    const stack = getCurrentStack(1);
+
+    this.validator.validateMethodParamOrThrow(
+      "plugins",
+      "setGlobalConfigSchematics",
+      "globalConfigSchematics",
+      z.instanceof(KVConfigSchematics),
+      globalConfigSchematics,
+      stack,
+    );
+
+    await this.port.callRpc(
+      "setGlobalConfigSchematics",
+      {
+        schematics: (
+          globalConfigSchematics as KVConfigSchematics<GlobalKVFieldValueTypeLibraryMap, any>
         ).serialize(),
       },
       { stack },
@@ -536,6 +565,7 @@ export class PluginsNamespace {
           const controller = new ToolsProviderController(
             this.client,
             message.pluginConfig,
+            message.globalPluginConfig,
             message.workingDirectoryPath,
             sessionAbortController.signal,
           );
@@ -751,6 +781,7 @@ export class PluginsNamespace {
           const controller = new GeneratorController(
             this.client,
             message.pluginConfig,
+            message.globalPluginConfig,
             message.toolDefinitions,
             message.workingDirectoryPath,
             connector,

--- a/packages/lms-client/src/plugins/processing/GeneratorController.ts
+++ b/packages/lms-client/src/plugins/processing/GeneratorController.ts
@@ -35,6 +35,7 @@ export class GeneratorController {
   public constructor(
     public readonly client: LMStudioClient,
     private readonly pluginConfig: KVConfig,
+    private readonly globalPluginConfig: KVConfig,
     private readonly toolDefinitions: Array<LLMTool>,
     private readonly workingDirectoryPath: string | null,
     private readonly connector: GeneratorConnector,
@@ -58,6 +59,17 @@ export class GeneratorController {
         TVirtualConfigSchematics
       >
     ).parse(this.pluginConfig);
+  }
+
+  public getGlobalPluginConfig<TVirtualConfigSchematics extends VirtualConfigSchematics>(
+    configSchematics: ConfigSchematics<TVirtualConfigSchematics>,
+  ): ParsedConfig<TVirtualConfigSchematics> {
+    return (
+      configSchematics as KVConfigSchematics<
+        GlobalKVFieldValueTypeLibraryMap,
+        TVirtualConfigSchematics
+      >
+    ).parse(this.globalPluginConfig);
   }
 
   /**

--- a/packages/lms-client/src/plugins/processing/ProcessingController.ts
+++ b/packages/lms-client/src/plugins/processing/ProcessingController.ts
@@ -209,6 +209,8 @@ export class ProcessingController {
     private readonly config: KVConfig,
     /** @internal */
     private readonly pluginConfig: KVConfig,
+    /** @internal */
+    private readonly globalPluginConfig: KVConfig,
     /**
      * When getting history, should the latest user input be included in the history?
      *
@@ -259,6 +261,17 @@ export class ProcessingController {
         TVirtualConfigSchematics
       >
     ).parse(this.pluginConfig);
+  }
+
+  public getGlobalPluginConfig<TVirtualConfigSchematics extends VirtualConfigSchematics>(
+    configSchematics: ConfigSchematics<TVirtualConfigSchematics>,
+  ): ParsedConfig<TVirtualConfigSchematics> {
+    return (
+      configSchematics as KVConfigSchematics<
+        GlobalKVFieldValueTypeLibraryMap,
+        TVirtualConfigSchematics
+      >
+    ).parse(this.globalPluginConfig);
   }
 
   /**

--- a/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
+++ b/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
@@ -17,6 +17,7 @@ export class ToolsProviderController {
   public constructor(
     public readonly client: LMStudioClient,
     private readonly pluginConfig: KVConfig,
+    private readonly globalPluginConfig: KVConfig,
     private readonly workingDirectoryPath: string | null,
     public readonly signal: AbortSignal,
   ) {}
@@ -37,5 +38,16 @@ export class ToolsProviderController {
         TVirtualConfigSchematics
       >
     ).parse(this.pluginConfig);
+  }
+
+  public getGlobalPluginConfig<TVirtualConfigSchematics extends VirtualConfigSchematics>(
+    configSchematics: ConfigSchematics<TVirtualConfigSchematics>,
+  ): ParsedConfig<TVirtualConfigSchematics> {
+    return (
+      configSchematics as KVConfigSchematics<
+        GlobalKVFieldValueTypeLibraryMap,
+        TVirtualConfigSchematics
+      >
+    ).parse(this.globalPluginConfig);
   }
 }

--- a/packages/lms-es-plugin-runner/src/generateEntryFile.ts
+++ b/packages/lms-es-plugin-runner/src/generateEntryFile.ts
@@ -17,6 +17,7 @@ const client = new LMStudioClient({
 let predictionLoopHandlerSet = false;
 let preprocessorSet = false;
 let configSchematicsSet = false;
+let globalConfigSchematicsSet = false;
 let toolsProviderSet = false;
 let generatorSet = false;
 
@@ -47,6 +48,14 @@ const pluginContext: PluginContext = {
     }
     configSchematicsSet = true;
     client.plugins.setConfigSchematics(configSchematics);
+    return pluginContext;
+  },
+  withGlobalConfigSchematics: (globalConfigSchematics) => {
+    if (globalConfigSchematicsSet) {
+      throw new Error("Global config schematics already registered");
+    }
+    globalConfigSchematicsSet = true;
+    client.plugins.setGlobalConfigSchematics(globalConfigSchematics);
     return pluginContext;
   },
   withToolsProvider: (toolsProvider) => {

--- a/packages/lms-external-backend-interfaces/src/pluginsBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/pluginsBackendInterface.ts
@@ -58,6 +58,7 @@ export function createPluginsBackendInterface() {
             input: chatMessageDataSchema,
             config: kvConfigSchema,
             pluginConfig: kvConfigSchema,
+            globalPluginConfig: kvConfigSchema,
             workingDirectoryPath: z.string().nullable(),
             /** Processing Context Identifier */
             pci: z.string(),
@@ -93,6 +94,7 @@ export function createPluginsBackendInterface() {
             taskId: z.string(),
             config: kvConfigSchema,
             pluginConfig: kvConfigSchema,
+            globalPluginConfig: kvConfigSchema,
             workingDirectoryPath: z.string().nullable(),
             /** Processing Context Identifier */
             pci: z.string(),
@@ -132,6 +134,7 @@ export function createPluginsBackendInterface() {
           z.object({
             type: z.literal("initSession"),
             pluginConfig: kvConfigSchema,
+            globalPluginConfig: kvConfigSchema,
             workingDirectoryPath: z.string().nullable(),
             sessionId: z.string(),
           }),
@@ -211,6 +214,7 @@ export function createPluginsBackendInterface() {
             taskId: z.string(),
             input: chatHistoryDataSchema,
             pluginConfig: kvConfigSchema,
+            globalPluginConfig: kvConfigSchema,
             toolDefinitions: z.array(llmToolSchema),
             workingDirectoryPath: z.string().nullable(),
           }),
@@ -339,6 +343,12 @@ export function createPluginsBackendInterface() {
         returns: z.void(),
       })
       .addRpcEndpoint("setConfigSchematics", {
+        parameter: z.object({
+          schematics: serializedKVConfigSchematicsSchema,
+        }),
+        returns: z.void(),
+      })
+      .addRpcEndpoint("setGlobalConfigSchematics", {
         parameter: z.object({
           schematics: serializedKVConfigSchematicsSchema,
         }),


### PR DESCRIPTION
Plugins can now supply global config schematics by doing `context.withGlobalConfigSchematics(xxx)` to register global config schematics.