### PR TITLE
Sync tool call execution by default

### DIFF
--- a/packages/lms-client/src/llm/LLM.act.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.act.heavy.test.ts
@@ -126,6 +126,7 @@ describe("LLM.act", () => {
       resolve();
     });
     const onToolCallRequestEnd = jest.fn();
+    const onToolCallRequestDequeued = jest.fn();
 
     const additionToolWithQueueControl = tool({
       name: "add",
@@ -152,6 +153,7 @@ describe("LLM.act", () => {
         temperature: 0,
         onPredictionCompleted,
         onToolCallRequestEnd,
+        onToolCallRequestDequeued,
       },
     );
 
@@ -174,6 +176,7 @@ describe("LLM.act", () => {
       expect.any(Number), // callId
       { isQueued: true }, // Second call is queued
     ]);
+    expect(onToolCallRequestDequeued).toHaveBeenCalledTimes(1);
   });
   it("should not queue up tool calls when allowParallelToolExecution is true", async () => {
     // In this test, we will make the model call the tool twice in parallel. We will then make the
@@ -194,6 +197,7 @@ describe("LLM.act", () => {
       resolve();
     });
     const onToolCallRequestEnd = jest.fn();
+    const onToolCallRequestDequeued = jest.fn();
 
     const additionToolWithQueueControl = tool({
       name: "add",
@@ -220,6 +224,7 @@ describe("LLM.act", () => {
         temperature: 0,
         onPredictionCompleted,
         onToolCallRequestEnd,
+        onToolCallRequestDequeued,
         allowParallelToolExecution: true,
       },
     );
@@ -240,5 +245,6 @@ describe("LLM.act", () => {
       expect.any(Number), // callId
       { isQueued: false }, // Second call is also not queued
     ]);
+    expect(onToolCallRequestDequeued).toHaveBeenCalledTimes(0);
   });
 });

--- a/packages/lms-client/src/llm/LLM.act.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.act.heavy.test.ts
@@ -33,7 +33,7 @@ describe("LLM.act", () => {
     });
   }, 60_000);
   it("should call the tool with the correct parameters", async () => {
-    const onMessage = jest.fn(a => console.info(a.toString()));
+    const onMessage = jest.fn();
     const onFirstToken = jest.fn();
     const onPredictionCompleted = jest.fn();
     const onPredictionFragment = jest.fn();

--- a/packages/lms-client/src/llm/LLM.act.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.act.heavy.test.ts
@@ -1,3 +1,4 @@
+import { makePromise } from "@lmstudio/lms-common";
 import { z } from "zod";
 import {
   type ChatMessage,
@@ -32,7 +33,7 @@ describe("LLM.act", () => {
     });
   }, 60_000);
   it("should call the tool with the correct parameters", async () => {
-    const onMessage = jest.fn();
+    const onMessage = jest.fn(a => console.info(a.toString()));
     const onFirstToken = jest.fn();
     const onPredictionCompleted = jest.fn();
     const onPredictionFragment = jest.fn();
@@ -107,5 +108,137 @@ describe("LLM.act", () => {
 
     expect(onRoundEnd).toHaveBeenCalledTimes(2);
     expect(onRoundEnd.mock.calls).toEqual([[0], [1]]);
+  });
+  it("should queue up tool calls", async () => {
+    // In this test, we will make the model call the tool twice in parallel. We will then make the
+    // first tool call be artificially long by using a promise that is not resolved until the
+    // prediction is completed (but not the round).
+
+    const calls: Array<string> = [];
+
+    // Promises that will only be resolved after the prediction is completed. This is to
+    // artificially lengthen the execution of the first tool call.
+    const { promise, resolve } = makePromise<void>();
+
+    const onPredictionCompleted = jest.fn(() => {
+      // Record predictionCompleted
+      calls.push("predictionCompleted");
+      resolve();
+    });
+    const onToolCallRequestEnd = jest.fn();
+
+    const additionToolWithQueueControl = tool({
+      name: "add",
+      description: "Add two numbers",
+      parameters: { a: z.number(), b: z.number() },
+      implementation: async ({ a, b }) => {
+        if (a === 1 && b === 3) {
+          calls.push("firstCall");
+          await promise; // Wait for the promise to be resolved
+          return 4;
+        } else if (a === 2 && b === 4) {
+          calls.push("secondCall");
+          return 6;
+        } else {
+          throw new Error(`Unexpected parameters: a=${a}, b=${b}`);
+        }
+      },
+    });
+
+    await model.act(
+      "Calculate 1 + 3 and 2 + 4 with the tool in parallel.",
+      [additionToolWithQueueControl],
+      {
+        temperature: 0,
+        onPredictionCompleted,
+        onToolCallRequestEnd,
+      },
+    );
+
+    expect(calls).toEqual([
+      "firstCall",
+      "predictionCompleted",
+      // Due to queueing, the second call will only be executed after prediction is completed
+      "secondCall",
+      "predictionCompleted", // Model will say stuff afterwards
+    ]);
+
+    expect(onToolCallRequestEnd).toHaveBeenCalledTimes(2);
+    expect(onToolCallRequestEnd.mock.calls[0]).toMatchObject([
+      0, // roundIndex
+      expect.any(Number), // callId
+      { isQueued: false }, // First call is not queued
+    ]);
+    expect(onToolCallRequestEnd.mock.calls[1]).toMatchObject([
+      0, // roundIndex
+      expect.any(Number), // callId
+      { isQueued: true }, // Second call is queued
+    ]);
+  });
+  it("should not queue up tool calls when allowParallelToolExecution is true", async () => {
+    // In this test, we will make the model call the tool twice in parallel. We will then make the
+    // first tool call be artificially long by using a promise that is not resolved until the
+    // prediction is completed (but not the round). However, since this time
+    // allowParallelToolExecution is true, the second tool call will be executed in parallel with
+    // the first one despite the first one taking longer to complete.
+
+    const calls: Array<string> = [];
+
+    // Promises that will only be resolved after the prediction is completed. This is to
+    // artificially lengthen the execution of the first tool call.
+    const { promise, resolve } = makePromise<void>();
+
+    const onPredictionCompleted = jest.fn(() => {
+      // Record predictionCompleted
+      calls.push("predictionCompleted");
+      resolve();
+    });
+    const onToolCallRequestEnd = jest.fn();
+
+    const additionToolWithQueueControl = tool({
+      name: "add",
+      description: "Add two numbers",
+      parameters: { a: z.number(), b: z.number() },
+      implementation: async ({ a, b }) => {
+        if (a === 1 && b === 3) {
+          calls.push("firstCall");
+          await promise; // Wait for the promise to be resolved
+          return 4;
+        } else if (a === 2 && b === 4) {
+          calls.push("secondCall");
+          return 6;
+        } else {
+          throw new Error(`Unexpected parameters: a=${a}, b=${b}`);
+        }
+      },
+    });
+
+    await model.act(
+      "Calculate 1 + 3 and 2 + 4 with the tool in parallel.",
+      [additionToolWithQueueControl],
+      {
+        temperature: 0,
+        onPredictionCompleted,
+        onToolCallRequestEnd,
+        allowParallelToolExecution: true,
+      },
+    );
+
+    expect(calls).toEqual([
+      "firstCall",
+      "secondCall",
+      "predictionCompleted", // First prediction completed
+      "predictionCompleted", // Model will say stuff afterwards
+    ]);
+    expect(onToolCallRequestEnd.mock.calls[0]).toMatchObject([
+      0, // roundIndex
+      expect.any(Number), // callId
+      { isQueued: false }, // First call is not queued
+    ]);
+    expect(onToolCallRequestEnd.mock.calls[1]).toMatchObject([
+      0, // roundIndex
+      expect.any(Number), // callId
+      { isQueued: false }, // Second call is also not queued
+    ]);
   });
 });

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -230,10 +230,12 @@ function splitActOpts<TStructuredOutputType>(
     onToolCallRequestStart,
     onToolCallRequestEnd,
     onToolCallRequestFailure,
+    onToolCallRequestDequeued,
     handleInvalidToolRequest,
     maxPredictionRounds,
     signal,
     preset,
+    allowParallelToolExecution,
     ...config
   } = opts;
   return [
@@ -249,10 +251,12 @@ function splitActOpts<TStructuredOutputType>(
       onToolCallRequestStart,
       onToolCallRequestEnd,
       onToolCallRequestFailure,
+      onToolCallRequestDequeued,
       handleInvalidToolRequest,
       maxPredictionRounds,
       signal,
       preset,
+      allowParallelToolExecution,
     },
   ];
 }

--- a/packages/lms-shared-types/src/llm/processing/ProcessingUpdate.ts
+++ b/packages/lms-shared-types/src/llm/processing/ProcessingUpdate.ts
@@ -316,6 +316,9 @@ export type ToolStatusStepStateStatus =
       error: string;
     }
   | {
+      type: "toolCallQueued";
+    }
+  | {
       type: "confirmingToolCall";
     }
   | {
@@ -340,6 +343,9 @@ export const toolStatusStepStateStatusSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("toolCallGenerationFailed"),
     error: z.string(),
+  }),
+  z.object({
+    type: z.literal("toolCallQueued"),
   }),
   z.object({
     type: z.literal("confirmingToolCall"),


### PR DESCRIPTION
Makes tool execution synchronous by default (i.e. later tool calls will wait for earlier tool calls to finish before continuing). This does not prevent parallel tool calls, only prevents parallel execution of those tool calls. This makes .act more safe when used with tools that have side-effects which cares about timing/ordering.

The old behavior can be opt back in by specifying `allowParallelToolExecution: true`, which will be more efficient if your tools can run for a long time + they are pure/don't care about timing or ordering.