### PR TITLE
Update URL for lms cli git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "packages/lms-cli"]
 	path = packages/lms-cli
-	url = git@github.com:lmstudio-ai/lmstudio-cli.git
+	url = https://github.com/lmstudio-ai/lms.git


### PR DESCRIPTION
`git clone https://github.com/lmstudio-ai/lmstudio-js.git --recursive` in the development instructions was failing because the submodule URL path was incorrect. it seems the repo was renamed but the submodule URL was not updated accordingly.

This PR updates the URL and also switches the URL format to use https instead of ssh since that will work better out of the box for most people who may not have SSH keys setup and since it's not really necessary for public repos anyways