### PR TITLE
Allow "applyPromptTemplate" to specify tools

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMApplyPromptTemplateOpts.ts
+++ b/packages/lms-shared-types/src/llm/LLMApplyPromptTemplateOpts.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { llmToolSchema, type LLMTool } from "./LLMToolUseSetting.js";
 
 /**
  * Options for applying a prompt template.
@@ -17,8 +18,15 @@ export interface LLMApplyPromptTemplateOpts {
    * Default: false
    */
   omitEosToken?: boolean;
+  /**
+   * Optional tool definitions to include in the prompt.
+   *
+   * @experimental This feature is experimental and may change in the future.
+   */
+  toolDefinitions?: Array<LLMTool>;
 }
 export const llmApplyPromptTemplateOptsSchema = z.object({
   omitBosToken: z.boolean().optional(),
   omitEosToken: z.boolean().optional(),
+  toolDefinitions: z.array(llmToolSchema).optional(),
 });


### PR DESCRIPTION
We will format the prompt with the tool definitions provided. Currently marked as experimental as we might adjust the "LLMTool" type later.