### PR TITLE
Unify deprecations and experimental tags

### DIFF
--- a/packages/lms-client/src/LMStudioClient.ts
+++ b/packages/lms-client/src/LMStudioClient.ts
@@ -143,7 +143,8 @@ export class LMStudioClient {
   public readonly files: FilesNamespace;
   public readonly repository: RepositoryNamespace;
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public readonly plugins: PluginsNamespace;
 

--- a/packages/lms-client/src/files/FilesNamespace.ts
+++ b/packages/lms-client/src/files/FilesNamespace.ts
@@ -114,7 +114,8 @@ export class FilesNamespace {
    *
    * This method can only be used in environments that have file system access (such as Node.js).
    *
-   * @deprecated Retrieval API is still in active development. Stay tuned for updates.
+   * @deprecated [DEP-RETRIEVAL] Retrieval API is still in active development. Stay tuned for
+   * updates.
    */
   public async prepareFile(path: string): Promise<FileHandle> {
     // Currently, exactly the same as prepareImage.
@@ -137,8 +138,8 @@ export class FilesNamespace {
    * Adds a temporary file to LM Studio. The content of the file is specified using base64. If you
    * are using Node.js and have a file laying around, consider using `prepareFile` instead.
    *
-   * @deprecated Retrieval API is still in active development. Stay tuned for updates.
-   */
+   * @deprecated [DEP-RETRIEVAL] Retrieval API is still in active development. Stay tuned for
+   * updates.   */
   public async prepareFileBase64(fileName: string, contentBase64: string): Promise<FileHandle> {
     // Currently, exactly the same as prepareImageBase64.
     const { identifier, fileType, sizeBytes } = await this.filesPort.callRpc("uploadFileBase64", {
@@ -149,8 +150,8 @@ export class FilesNamespace {
   }
 
   /**
-   * @deprecated Retrieval API is still in active development. Stay tuned for updates.
-   */
+   * @deprecated [DEP-RETRIEVAL] Retrieval API is still in active development. Stay tuned for
+   * updates.   */
   public async retrieve(
     query: string,
     files: Array<FileHandle>,
@@ -358,7 +359,8 @@ export class FilesNamespace {
   /**
    * Parse a document
    *
-   * @deprecated Document parsing API is still in active development. Stay tuned for updates.
+   * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+   * updates.
    */
   public async parseDocument(fileHandle: FileHandle, opts: ParseDocumentOpts = {}) {
     const stack = getCurrentStack(1);
@@ -424,7 +426,8 @@ export class FilesNamespace {
   /**
    * Get the parsing method for a document.
    *
-   * @deprecated Document parsing API is still in active development. Stay tuned for updates.
+   * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+   * updates.
    */
   public async getDocumentParsingLibrary(
     fileHandle: FileHandle,

--- a/packages/lms-client/src/files/ParseDocumentOpts.ts
+++ b/packages/lms-client/src/files/ParseDocumentOpts.ts
@@ -9,7 +9,8 @@ import { z } from "zod";
  * Options for parsing a document.
  *
  * @public
- * @deprecated Document parsing is still in development. Stay tuned for updates.
+ * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+ * updates.
  */
 export type ParseDocumentOpts = DocumentParsingOpts & {
   /**

--- a/packages/lms-client/src/files/ParseDocumentResult.ts
+++ b/packages/lms-client/src/files/ParseDocumentResult.ts
@@ -4,7 +4,8 @@ import { type DocumentParsingLibraryIdentifier } from "@lmstudio/lms-shared-type
  * The result of parsing a document.
  *
  * @public
- * @experimental Document parsing is still in development. Stay tuned for updates.
+ * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+ * updates.
  */
 export interface ParseDocumentResult {
   /**

--- a/packages/lms-client/src/llm/GeneratorPredictionResult.ts
+++ b/packages/lms-client/src/llm/GeneratorPredictionResult.ts
@@ -7,7 +7,8 @@ import { type BasePredictionResult } from "./PredictionResult.js";
  * generated text.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+ * This may change in the future without warning.
  */
 export class GeneratorPredictionResult implements BasePredictionResult {
   public constructor(

--- a/packages/lms-client/src/llm/LLMGeneratorHandle.ts
+++ b/packages/lms-client/src/llm/LLMGeneratorHandle.ts
@@ -25,7 +25,8 @@ import { toolToLLMTool, type Tool } from "./tool.js";
  * Options for {@link LLMGeneratorHandle#respond}.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+ * This may change in the future without warning.
  */
 export interface LLMGeneratorPredictionOpts {
   /**
@@ -82,7 +83,8 @@ const llmGeneratorPredictionOptsSchema = z.object({
  * Options for the LLM generator's act method.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+ * This may change in the future without warning.
  */
 export type LLMGeneratorActOpts = LLMActBaseOpts<GeneratorPredictionResult> & {
   /**
@@ -103,7 +105,8 @@ export const llmGeneratorActOptsSchema = llmActBaseOptsSchema.extend({
  * Represents a handle for a generator that can act as a LLM.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+ * This may change in the future without warning.
  */
 export class LLMGeneratorHandle {
   /**

--- a/packages/lms-client/src/llm/LLMNamespace.ts
+++ b/packages/lms-client/src/llm/LLMNamespace.ts
@@ -77,7 +77,8 @@ export class LLMNamespace extends ModelNamespace<
     return new LLMDynamicHandle(port, specifier, validator, logger);
   }
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+   * This may change in the future without warning.
    */
   public createGeneratorHandle(pluginIdentifier: string): LLMGeneratorHandle {
     return new LLMGeneratorHandle(this.port, pluginIdentifier, this.validator, this.logger);

--- a/packages/lms-client/src/llm/OngoingGeneratorPrediction.ts
+++ b/packages/lms-client/src/llm/OngoingGeneratorPrediction.ts
@@ -33,7 +33,8 @@ import { GeneratorPredictionResult } from "./GeneratorPredictionResult";
  * ```
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-GEN-PREDICT] Using generator plugins programmatically is still in development.
+ * This may change in the future without warning.
  */
 export class OngoingGeneratorPrediction extends StreamablePromise<
   LLMPredictionFragment,

--- a/packages/lms-client/src/llm/PredictionResult.ts
+++ b/packages/lms-client/src/llm/PredictionResult.ts
@@ -18,15 +18,11 @@ export interface BasePredictionResult {
   /**
    * Part of the generated text that is "reasoning" content. For example, text inside <think>
    * tags.
-   *
-   * @experimental The name of this field may change in the future.
    */
   reasoningContent: string;
   /**
    * Part of the generated text that is not "reasoning" content. For example, text outside <think>
    * tags.
-   *
-   * @experimental The name of this field may change in the future.
    */
   nonReasoningContent: string;
 }
@@ -50,16 +46,12 @@ export class PredictionResult implements BasePredictionResult {
      * Part of the generated text that is "reasoning" content. For example, text inside <think>
      * tags. You can adjust what is considered reasoning content by changing the `reasoningParsing`
      * field when performing the prediction.
-     *
-     * @experimental The name of this field may change in the future.
      */
     public readonly reasoningContent: string,
     /**
      * Part of the generated that is not "reasoning" content. For example, text outside <think>
      * tags. You can adjust what is considered reasoning content by changing the `reasoningParsing`
      * field when performing the prediction.
-     *
-     * @experimental The name of this field may change in the future.
      */
     public readonly nonReasoningContent: string,
     /**
@@ -78,13 +70,15 @@ export class PredictionResult implements BasePredictionResult {
     /**
      * The configuration used to load the model. Not stable, subject to change.
      *
-     * @deprecated Not stable - subject to change
+     * @deprecated [DEP-RAW-CONFIG] Raw config access API is still in active development. Stay
+     * turned for updates.
      */
     public readonly loadConfig: KVConfig,
     /**
      * The configuration used for the prediction. Not stable, subject to change.
      *
-     * @deprecated Not stable - subject to change
+     * @deprecated [DEP-RAW-CONFIG] Raw config access API is still in active development. Stay
+     * turned for updates.
      */
     public readonly predictionConfig: KVConfig,
   ) {}

--- a/packages/lms-client/src/llm/act.ts
+++ b/packages/lms-client/src/llm/act.ts
@@ -193,8 +193,9 @@ class FIFOQueue implements QueueInterface {
 /**
  * Represents an error that is caused by invalid tool call request.
  *
- * @experimental This class is experimental and may change in the future.
  * @public
+ * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+ * change in the future
  */
 export class ToolCallRequestError extends Error {
   public constructor(
@@ -206,7 +207,8 @@ export class ToolCallRequestError extends Error {
      *
      * This field is not always available, and may be `undefined`.
      *
-     * @experimental This field is experimental and may change in the future.
+     * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+     * change in the future
      */
     public readonly rawContent: string | undefined,
   ) {
@@ -295,7 +297,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * called. It is guaranteed that each `invocation` of `onToolCallRequestStart` is paired
    * with exactly one `onToolCallRequestEnd` or `onToolCallRequestFailure`.
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestStart?: (roundIndex: number, callId: number) => void;
   /**
@@ -304,7 +307,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * This hook is intended for updating the UI to show the name of the tool that is being called.
    * There is no guarantee that this callback will be called.
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestNameReceived?: (roundIndex: number, callId: number, name: string) => void;
   /**
@@ -316,7 +320,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * Note, when piecing together all the argument fragments, there is no guarantee that the result
    * will be valid JSON, as some models may not use JSON to represent tool calls.
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestArgumentFragmentGenerated?: (
     roundIndex: number,
@@ -332,7 +337,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * Instead, you can use this callback to update the UI or maintain the context. If you are unsure
    * what to do with this callback, you can ignore it.
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestEnd?: (
     roundIndex: number,
@@ -368,7 +374,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * This hook is intended for updating the UI, such as showing "a tool call has failed to
    * generate.".
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestFailure?: (
     roundIndex: number,
@@ -388,7 +395,8 @@ export interface LLMActBaseOpts<TPredictionResult> {
    * If the tool call themselves are very fast, this callback may never be called, because the
    * the first tool call might finish before the second tool call request is generated.
    *
-   * @experimental This option is experimental and may change in the future.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   onToolCallRequestDequeued?: (roundIndex: number, callId: number) => void;
   /**

--- a/packages/lms-client/src/llm/tool.ts
+++ b/packages/lms-client/src/llm/tool.ts
@@ -57,8 +57,8 @@ export interface ToolCallContext {
    * @remarks This field is not the same as the `toolCallId` inside the tool call request, as the
    * existence and format of that ID is model dependent.
    *
-   * @experimental This field is not stable and will likely change in the future as we design better
-   * ways to match up tool calls.
+   * @experimental [EXP-GRANULAR-ACT] More granular .act status reporting is experimental and may
+   * change in the future
    */
   callId: number;
 }
@@ -98,10 +98,10 @@ export const functionToolSchema = toolBaseSchema.extend({
 });
 
 /**
- * A tool that is a raw function.
+ * A tool that has a its parameters defined by a JSON schema.
  *
  * @public
- * @experimental Not stable, will likely change in the future.
+ * @experimental [EXP-RAW-FUNCTION] This is an experimental feature and may change in the future.
  */
 export interface RawFunctionTool extends ToolBase {
   type: "rawFunction";

--- a/packages/lms-client/src/plugins/PluginsNamespace.ts
+++ b/packages/lms-client/src/plugins/PluginsNamespace.ts
@@ -142,7 +142,8 @@ export class PluginsNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public async registerDevelopmentPlugin(
     opts: RegisterDevelopmentPluginOpts,
@@ -200,7 +201,8 @@ export class PluginsNamespace {
    * CAVEAT: Currently, we do not wait for the reindex to complete before returning. In the future,
    * we will change this behavior and only return after the reindex is completed.
    *
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public async reindexPlugins() {
     const stack = getCurrentStack(1);
@@ -210,7 +212,8 @@ export class PluginsNamespace {
   /**
    * Sets the preprocessor to be used by the plugin represented by this client.
    *
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public setPreprocessor(preprocessor: Preprocessor) {
     const stack = getCurrentStack(1);
@@ -343,7 +346,8 @@ export class PluginsNamespace {
   /**
    * Sets the preprocessor to be used by the plugin represented by this client.
    *
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-PLUGIN-PREDICTION-LOOP-HANDLER] Prediction loop handler support is still in
+   * development. Stay tuned for updates.
    */
   public setPredictionLoopHandler(predictionLoopHandler: PredictionLoopHandler) {
     const stack = getCurrentStack(1);
@@ -452,7 +456,8 @@ export class PluginsNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public async setConfigSchematics(configSchematics: ConfigSchematics<any>) {
     const stack = getCurrentStack(1);
@@ -478,7 +483,8 @@ export class PluginsNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public async setGlobalConfigSchematics(globalConfigSchematics: ConfigSchematics<any>) {
     const stack = getCurrentStack(1);
@@ -504,7 +510,8 @@ export class PluginsNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public setToolsProvider(toolsProvider: ToolsProvider) {
     const stack = getCurrentStack(1);
@@ -772,7 +779,8 @@ export class PluginsNamespace {
   /**
    * Sets the generator to be used by the plugin represented by this client.
    *
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public setGenerator(generator: Generator) {
     const stack = getCurrentStack(1);
@@ -886,7 +894,8 @@ export class PluginsNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+   * future without warning.
    */
   public async initCompleted() {
     const stack = getCurrentStack(1);

--- a/packages/lms-client/src/plugins/processing/BaseController.ts
+++ b/packages/lms-client/src/plugins/processing/BaseController.ts
@@ -14,7 +14,8 @@ import {
  * The base class for all controllers.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+ * future without warning.
  */
 export abstract class BaseController {
   public constructor(

--- a/packages/lms-client/src/plugins/processing/GeneratorController.ts
+++ b/packages/lms-client/src/plugins/processing/GeneratorController.ts
@@ -24,7 +24,8 @@ export interface GeneratorConnector {
  * Controller for a generator.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+ * future without warning.
  */
 export class GeneratorController extends BaseController {
   /**

--- a/packages/lms-client/src/plugins/processing/ProcessingController.ts
+++ b/packages/lms-client/src/plugins/processing/ProcessingController.ts
@@ -161,7 +161,8 @@ export interface CreateCitationBlockOpts {
  * Options to use with {@link ProcessingController#requestConfirmToolCall}.
  *
  * @public
- * @experimental WIP
+ * @deprecated [DEP-PLUGIN-PREDICTION-LOOP-HANDLER] Prediction loop handler support is still in
+ * development. Stay tuned for updates.
  */
 export interface RequestConfirmToolCallOpts {
   callId: number;
@@ -174,7 +175,8 @@ export interface RequestConfirmToolCallOpts {
  * Return type of {@link ProcessingController#requestConfirmToolCall}.
  *
  * @public
- * @experimental WIP
+ * @deprecated [DEP-PLUGIN-PREDICTION-LOOP-HANDLER] Prediction loop handler support is still in
+ * development. Stay tuned for updates.
  */
 export type RequestConfirmToolCallResult =
   | {

--- a/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
+++ b/packages/lms-client/src/plugins/processing/ToolsProviderController.ts
@@ -6,7 +6,8 @@ import { BaseController } from "./BaseController.js";
  * Controller for tools provider.
  *
  * @public
- * @deprecated Plugin support is still in development. Stay tuned for updates.
+ * @experimental [EXP-PLUGIN-CORE] Plugin support is still in development. This may change in the
+ * future without warning.
  */
 export class ToolsProviderController extends BaseController {
   /**

--- a/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
+++ b/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
@@ -20,7 +20,8 @@ interface ArtifactDownloadPlannerCurrentDownload {
 /**
  * Options for the {@link ArtifactDownloadPlanner#download} method.
  *
- * @experimental This type is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export interface ArtifactDownloadPlannerDownloadOpts {
@@ -38,7 +39,8 @@ const artifactDownloadPlannerDownloadOptsSchema = z.object({
  * Represents a planner to download an artifact. The plan is not guaranteed to be ready until you
  * await on the method "untilReady".
  *
- * @experimental The entirety of this class is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export class ArtifactDownloadPlanner {

--- a/packages/lms-client/src/repository/RepositoryNamespace.ts
+++ b/packages/lms-client/src/repository/RepositoryNamespace.ts
@@ -168,7 +168,8 @@ export class RepositoryNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public async installPluginDependencies(pluginFolder: string) {
     const stack = getCurrentStack(1);
@@ -184,7 +185,8 @@ export class RepositoryNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public async downloadArtifact(opts: DownloadArtifactOpts) {
     const stack = getCurrentStack(1);
@@ -242,7 +244,8 @@ export class RepositoryNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public async pushArtifact(opts: PushArtifactOpts): Promise<void> {
     const stack = getCurrentStack(1);
@@ -280,7 +283,8 @@ export class RepositoryNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public async getLocalArtifactFileList(path: string): Promise<LocalArtifactFileList> {
     const stack = getCurrentStack(1);
@@ -301,7 +305,8 @@ export class RepositoryNamespace {
   }
 
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public async ensureAuthenticated(opts: EnsureAuthenticatedOpts) {
     const stack = getCurrentStack(1);
@@ -370,7 +375,8 @@ export class RepositoryNamespace {
     `);
   });
   /**
-   * @deprecated Plugin support is still in development. Stay tuned for updates.
+   * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+   * tuned for updates.
    */
   public createArtifactDownloadPlanner(
     opts: CreateArtifactDownloadPlannerOpts,

--- a/packages/lms-common/src/text.ts
+++ b/packages/lms-common/src/text.ts
@@ -10,7 +10,6 @@ const compiledTemplatesCache = new WeakMap<TemplateStringsArray, Array<string>>(
  * The allowed types for the values in the `text` tag function.
  *
  * @public
- * @experimental This type may change in the future.
  */
 export type TextAllowedTypes = string | number | object;
 
@@ -24,8 +23,13 @@ export type TextAllowedTypes = string | number | object;
  *
  * Note: Only spaces are considered.
  *
+ * @remarks
+ *
+ * The exact implementation of this function is not guaranteed to be the same, as we may add
+ * additional edge case handling in the future. However, the general behavior should remain the
+ * same.
+ *
  * @public
- * @experimental The behavior of this function may change in the future.
  */
 export function text(strings: TemplateStringsArray, ...values: ReadonlyArray<TextAllowedTypes>) {
   if (values.length + 1 !== strings.length) {

--- a/packages/lms-shared-types/src/files/DocumentParsingOpts.ts
+++ b/packages/lms-shared-types/src/files/DocumentParsingOpts.ts
@@ -4,7 +4,8 @@ import { z } from "zod";
  * Represents the library and version of a document parsing library.
  *
  * @public
- * @experimental Document parsing is still in development. Stay tuned for updates.
+ * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+ * updates.
  */
 export type DocumentParsingLibraryIdentifier = {
   /**
@@ -26,7 +27,8 @@ export const documentParsingLibraryIdentifierSchema = z.object({
  * Options for parsing a document.
  *
  * @public
- * @deprecated Document parsing is still in development. Stay tuned for updates.
+ * @deprecated [DEP-DOC-PARSE] Document parsing API is still in active development. Stay tuned for
+ * updates.
  */
 export type DocumentParsingOpts = {
   /**

--- a/packages/lms-shared-types/src/llm/LLMApplyPromptTemplateOpts.ts
+++ b/packages/lms-shared-types/src/llm/LLMApplyPromptTemplateOpts.ts
@@ -20,8 +20,6 @@ export interface LLMApplyPromptTemplateOpts {
   omitEosToken?: boolean;
   /**
    * Optional tool definitions to include in the prompt.
-   *
-   * @experimental This feature is experimental and may change in the future.
    */
   toolDefinitions?: Array<LLMTool>;
 }

--- a/packages/lms-shared-types/src/llm/processing/ProcessingRequest.ts
+++ b/packages/lms-shared-types/src/llm/processing/ProcessingRequest.ts
@@ -28,7 +28,8 @@ export const processingRequestConfirmToolCallSchema = z.object({
 });
 
 /**
- * @experimental WIP
+ * @deprecated [DEP-PLUGIN-PREDICTION-LOOP-HANDLER] Prediction loop handler support is still in
+ * development. Stay tuned for updates.
  */
 export type ProcessingRequestTextInput = {
   type: "textInput";
@@ -72,7 +73,8 @@ export const processingRequestResponseConfirmToolCallSchema = z.object({
 });
 
 /**
- * @experimental WIP
+ * @deprecated [DEP-PLUGIN-PREDICTION-LOOP-HANDLER] Prediction loop handler support is still in
+ * development. Stay tuned for updates.
  */
 export type ProcessingRequestResponseTextInput = {
   type: "textInput";

--- a/packages/lms-shared-types/src/repository/ArtifactDownloadPlan.ts
+++ b/packages/lms-shared-types/src/repository/ArtifactDownloadPlan.ts
@@ -9,7 +9,8 @@ import {
 /**
  * Represents information about a model in an artifact download plan.
  *
- * @experimental This type is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export type ArtifactDownloadPlanModelInfo = {
@@ -29,7 +30,8 @@ export const artifactDownloadPlanModelInfoSchema: ZodSchema<ArtifactDownloadPlan
 /**
  * Represents the state of a node in an artifact download plan.
  *
- * @experimental This type is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export type ArtifactDownloadPlanNodeState = "pending" | "fetching" | "satisfied" | "completed";
@@ -40,7 +42,8 @@ export const artifactDownloadPlanNodeStateSchema: ZodSchema<ArtifactDownloadPlan
 /**
  * Represents the state of a node in an artifact download plan.
  *
- * @experimental This type is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export type ArtifactDownloadPlanNode =
@@ -84,7 +87,8 @@ export const artifactDownloadPlanNodeSchema = z.discriminatedUnion("type", [
 /**
  * Represents a plan for downloading artifacts.
  *
- * @experimental This type is experimental and may change at any time.
+ * @deprecated [DEP-HUB-API-ACCESS] LM Studio Hub API access is still in active development. Stay
+ * tuned for updates.
  * @public
  */
 export interface ArtifactDownloadPlan {


### PR DESCRIPTION
We use `@deprecated` and `@experimental` to mark APIs that are not yet stable yet. This PR unifies the language so they can be replaced easily in the future. In addition, prompt all plugins related APIs (expect those of prediction loop handler) to experimental, so they will now show up in auto complete.