### PR TITLE
Allow root $defs in tool schema

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
+++ b/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
@@ -11,6 +11,7 @@ export type LLMToolParameters = {
   properties: Record<string, any>;
   required?: string[];
   additionalProperties?: boolean;
+  $defs?: Record<string, any>;
 };
 
 export const llmToolParametersSchema = z.discriminatedUnion("type", [
@@ -19,6 +20,7 @@ export const llmToolParametersSchema = z.discriminatedUnion("type", [
     properties: z.record(jsonSerializableSchema),
     required: z.array(z.string()).optional(),
     additionalProperties: z.boolean().optional(),
+    $defs: z.record(jsonSerializableSchema).optional(),
   }),
   // add more parameter types here
   // ...


### PR DESCRIPTION
It appears there is no way to create a tool with root level $defs using the TypeScript SDK. Thus tested using the following python MCP:

```py
# server.py
from mcp.server.fastmcp import FastMCP
from pydantic import BaseModel

# Create an MCP server
mcp = FastMCP("Demo")

class AA(BaseModel):
    a: int


# Add an addition tool
@mcp.tool()
def sum(a: AA, b: AA) -> int:
    """Add two numbers"""
    return a + b
```

`lmsd log stream` output:

```
input: "<start_of_turn>user
The following tools are available for you to use:
[
  {
    "type": "function",
    "function": {
      "name": "sum",
      "description": "Add two numbers",
      "parameters": {
        "type": "object",
        "properties": {
          "a": {
            "$ref": "#/$defs/AA"
          },
          "b": {
            "$ref": "#/$defs/AA"
          }
        },
        "required": [
          "a",
          "b"
        ],
        "$defs": {
          "AA": {
            "properties": {
              "a": {
                "title": "A",
                "type": "integer"
              }
            },
            "required": [
              "a"
            ],
            "title": "AA",
            "type": "object"
          }
        }
      }
    }
  }
]

You can call available tools using this exact format:
<rest of output omitted>
```