### PR TITLE
Change the revoked auth event logging to a debug

### DIFF
--- a/packages/lms-communication-server/src/AuthenticatedWsServer.ts
+++ b/packages/lms-communication-server/src/AuthenticatedWsServer.ts
@@ -135,7 +135,7 @@ export class AuthenticatedWsServer<TContext extends Context> extends WsServer<TC
           holder.drop();
         });
         authenticationRevokedEvent.subscribeOnce(() => {
-          this.logger.warn("Terminating connection because authentication was revoked");
+          this.logger.debug("Terminating connection because authentication was revoked");
           try {
             ws.close();
           } catch (error) {


### PR DESCRIPTION
## Overview

Converts the authentication revoke event logs to a debug instead of a warn as it is an expected behavior on disconnect