### PR TITLE
Unimplemented tool support in .act

### DIFF
--- a/packages/lms-client/src/index.ts
+++ b/packages/lms-client/src/index.ts
@@ -46,7 +46,7 @@ export type {
   PredictionResult,
   StructuredPredictionResult,
 } from "./llm/PredictionResult.js";
-export { rawFunctionTool, tool } from "./llm/tool.js";
+export { rawFunctionTool, tool, unimplementedRawFunctionTool } from "./llm/tool.js";
 export type { FunctionTool, RawFunctionTool, Tool, ToolBase, ToolCallContext } from "./llm/tool.js";
 export { ToolCallRequestError } from "./llm/ToolCallRequestError.js";
 export { LMStudioClient } from "./LMStudioClient.js";

--- a/publish/sdk/src/index.ts
+++ b/publish/sdk/src/index.ts
@@ -9,6 +9,7 @@ export {
   rawFunctionTool,
   tool,
   ToolCallRequestError,
+  unimplementedRawFunctionTool,
 } from "@lmstudio/lms-client";
 export { MaybeMutable, text } from "@lmstudio/lms-common";
 export { kvValueTypesLibrary } from "@lmstudio/lms-kv-config";


### PR DESCRIPTION
Adds support for unimplemented tools (experimental). When an unimplemented tool is passed into .act, upon called, instead of failing, it gracefully terminates .act and return the control back to the user.