### PR TITLE
Allow feeding external error into *WSClientTransport

### DIFF
--- a/packages/lms-communication-client/src/AuthenticatedWsClientTransport.ts
+++ b/packages/lms-communication-client/src/AuthenticatedWsClientTransport.ts
@@ -8,10 +8,16 @@ import {
 } from "@lmstudio/lms-communication";
 import { WsClientTransport } from "./WsClientTransport.js";
 
+interface AuthenticatedWsClientTransportConstructorOpts {
+  parentLogger?: LoggerInterface;
+  abortSignal?: AbortSignal;
+}
+
 interface Opts {
   url: string | Promise<string>;
   clientIdentifier: string;
   clientPasskey: string;
+  abortSignal?: AbortSignal;
 }
 
 export class AuthenticatedWsClientTransport extends WsClientTransport {
@@ -24,14 +30,15 @@ export class AuthenticatedWsClientTransport extends WsClientTransport {
     private readonly clientPasskey: string,
     receivedMessage: (message: ServerToClientMessage) => void,
     errored: (error: any) => void,
-    parentLogger?: LoggerInterface,
+    { parentLogger, abortSignal }: AuthenticatedWsClientTransportConstructorOpts = {},
   ) {
-    super(url, receivedMessage, errored, parentLogger);
+    super(url, receivedMessage, errored, { parentLogger, abortSignal });
   }
   public static createAuthenticatedWsClientTransportFactory({
     url,
     clientIdentifier,
     clientPasskey,
+    abortSignal,
   }: Opts): ClientTransportFactory {
     return (receivedMessage, errored, parentLogger) =>
       new AuthenticatedWsClientTransport(
@@ -40,7 +47,7 @@ export class AuthenticatedWsClientTransport extends WsClientTransport {
         clientPasskey,
         receivedMessage,
         errored,
-        parentLogger,
+        { parentLogger, abortSignal },
       );
   }
   protected override onWsOpen() {

--- a/packages/lms-communication-client/src/WsClientTransport.ts
+++ b/packages/lms-communication-client/src/WsClientTransport.ts
@@ -85,13 +85,17 @@ export class WsClientTransport extends ClientTransport {
 
       const abortSignal = this.abortSignal;
       if (abortSignal !== undefined) {
-        const abortListener = () => {
+        if (abortSignal.aborted) {
           this.onWsError(abortSignal.reason);
-        };
-        abortSignal.addEventListener("abort", abortListener, { once: true });
-        this.ws.addEventListener("close", () => {
-          abortSignal.removeEventListener("abort", abortListener);
-        });
+        } else {
+          const abortListener = () => {
+            this.onWsError(abortSignal.reason);
+          };
+          abortSignal.addEventListener("abort", abortListener, { once: true });
+          this.ws.addEventListener("close", () => {
+            abortSignal.removeEventListener("abort", abortListener);
+          });
+        }
       }
     });
   }


### PR DESCRIPTION
There are cases where we know a connection is broken but not necessarily the TCP stack. (for example, if we run the server in a process that we control and that process is killed)

This PR makes so that it is possible to feed external errors into WSClientTransport, which upon triggered, will poison the transport and gracefully terminate all on going requests.