### PR TITLE
Start and stop server using RPC

### DIFF
--- a/packages/lms-client/src/system/SystemNamespace.ts
+++ b/packages/lms-client/src/system/SystemNamespace.ts
@@ -105,4 +105,21 @@ export class SystemNamespace {
     const stack = getCurrentStack(1);
     return await this.systemPort.callRpc("getExperimentFlags", undefined, { stack });
   }
+
+  public async startAPIServer(port: number, cors: boolean) {
+    const stack = getCurrentStack(1);
+
+    return await this.systemPort.callRpc(
+      "startAPIServer",
+      { port, cors },
+      {
+        stack,
+      },
+    );
+  }
+
+  public async stopAPIServer() {
+    const stack = getCurrentStack(1);
+    return await this.systemPort.callRpc("stopAPIServer", undefined, { stack });
+  }
 }

--- a/packages/lms-client/src/system/SystemNamespace.ts
+++ b/packages/lms-client/src/system/SystemNamespace.ts
@@ -15,7 +15,7 @@ import {
 } from "@lmstudio/lms-shared-types";
 import { z } from "zod";
 
-const startHTTPServerOptsSchema = z.object({
+const startHttpServerOptsSchema = z.object({
   port: z
     .number()
     .int()
@@ -27,7 +27,7 @@ const startHTTPServerOptsSchema = z.object({
     .describe("Enable CORS on the API server. Allows any website to access the server."),
 });
 
-type StartHTTPServerOpts = z.infer<typeof startHTTPServerOptsSchema>;
+type StartHttpServerOpts = z.infer<typeof startHttpServerOptsSchema>;
 
 /** @public */
 export class SystemNamespace {
@@ -125,19 +125,19 @@ export class SystemNamespace {
    *
    * @experimental
    */
-  public async startHTTPServer(opts: StartHTTPServerOpts) {
+  public async startHttpServer(opts: StartHttpServerOpts) {
     const stack = getCurrentStack(1);
 
     opts = this.validator.validateMethodParamOrThrow(
       "client.system",
-      "startHTTPServer",
+      "startHttpServer",
       "args",
-      startHTTPServerOptsSchema,
+      startHttpServerOptsSchema,
       opts,
     );
 
     return await this.systemPort.callRpc(
-      "startHTTPServer",
+      "startHttpServer",
       { port: opts.port, cors: opts.cors },
       {
         stack,
@@ -150,8 +150,8 @@ export class SystemNamespace {
    *
    * @experimental
    */
-  public async stopHTTPServer() {
+  public async stopHttpServer() {
     const stack = getCurrentStack(1);
-    return await this.systemPort.callRpc("stopHTTPServer", undefined, { stack });
+    return await this.systemPort.callRpc("stopHttpServer", undefined, { stack });
   }
 }

--- a/packages/lms-client/src/system/SystemNamespace.ts
+++ b/packages/lms-client/src/system/SystemNamespace.ts
@@ -15,6 +15,20 @@ import {
 } from "@lmstudio/lms-shared-types";
 import { z } from "zod";
 
+const startHTTPServerOptsSchema = z.object({
+  port: z
+    .number()
+    .int()
+    .min(1)
+    .max(65535)
+    .describe("Port to run the API server on. Must be between 1 and 65535."),
+  cors: z
+    .boolean()
+    .describe("Enable CORS on the API server. Allows any website to access the server."),
+});
+
+type StartHTTPServerOpts = z.infer<typeof startHTTPServerOptsSchema>;
+
 /** @public */
 export class SystemNamespace {
   /** @internal */
@@ -106,20 +120,38 @@ export class SystemNamespace {
     return await this.systemPort.callRpc("getExperimentFlags", undefined, { stack });
   }
 
-  public async startAPIServer(port: number, cors: boolean) {
+  /**
+   * Starts the API server on the specified port.
+   *
+   * @experimental
+   */
+  public async startHTTPServer(opts: StartHTTPServerOpts) {
     const stack = getCurrentStack(1);
 
+    opts = this.validator.validateMethodParamOrThrow(
+      "client.system",
+      "startHTTPServer",
+      "args",
+      startHTTPServerOptsSchema,
+      opts,
+    );
+
     return await this.systemPort.callRpc(
-      "startAPIServer",
-      { port, cors },
+      "startHTTPServer",
+      { port: opts.port, cors: opts.cors },
       {
         stack,
       },
     );
   }
 
-  public async stopAPIServer() {
+  /**
+   * Stops the API server if it is running.
+   *
+   * @experimental
+   */
+  public async stopHTTPServer() {
     const stack = getCurrentStack(1);
-    return await this.systemPort.callRpc("stopAPIServer", undefined, { stack });
+    return await this.systemPort.callRpc("stopHTTPServer", undefined, { stack });
   }
 }

--- a/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
@@ -46,14 +46,14 @@ export function createSystemBackendInterface() {
         parameter: z.void(),
         returns: z.array(z.string()),
       })
-      .addRpcEndpoint("startAPIServer", {
+      .addRpcEndpoint("startHTTPServer", {
         parameter: z.object({
           port: z.number().int().min(1).max(65535).optional(),
           cors: z.boolean().optional(),
         }),
         returns: z.void(),
       })
-      .addRpcEndpoint("stopAPIServer", {
+      .addRpcEndpoint("stopHTTPServer", {
         parameter: z.void(),
         returns: z.void(),
       })

--- a/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
@@ -46,14 +46,14 @@ export function createSystemBackendInterface() {
         parameter: z.void(),
         returns: z.array(z.string()),
       })
-      .addRpcEndpoint("startHTTPServer", {
+      .addRpcEndpoint("startHttpServer", {
         parameter: z.object({
           port: z.number().int().min(1).max(65535).optional(),
           cors: z.boolean().optional(),
         }),
         returns: z.void(),
       })
-      .addRpcEndpoint("stopHTTPServer", {
+      .addRpcEndpoint("stopHttpServer", {
         parameter: z.void(),
         returns: z.void(),
       })

--- a/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/systemBackendInterface.ts
@@ -46,6 +46,17 @@ export function createSystemBackendInterface() {
         parameter: z.void(),
         returns: z.array(z.string()),
       })
+      .addRpcEndpoint("startAPIServer", {
+        parameter: z.object({
+          port: z.number().int().min(1).max(65535).optional(),
+          cors: z.boolean().optional(),
+        }),
+        returns: z.void(),
+      })
+      .addRpcEndpoint("stopAPIServer", {
+        parameter: z.void(),
+        returns: z.void(),
+      })
   );
 }
 


### PR DESCRIPTION
## Overview

This would expose the `lms` client to be able to use stop and start server RPC calls