### PR TITLE
Ryan/gpt oss structural handling

### DIFF
--- a/packages/lms-client/src/llm/OngoingGeneratorPrediction.ts
+++ b/packages/lms-client/src/llm/OngoingGeneratorPrediction.ts
@@ -43,10 +43,12 @@ export class OngoingGeneratorPrediction extends StreamablePromise<
   protected override async collect(fragments: ReadonlyArray<LLMPredictionFragment>) {
     const content = fragments.map(({ content }) => content).join("");
     const reasoningContent = fragments
+      .filter(({ isStructural }) => !isStructural)
       .filter(({ reasoningType }) => reasoningType === "reasoning")
       .map(({ content }) => content)
       .join("");
     const nonReasoningContent = fragments
+      .filter(({ isStructural }) => !isStructural)
       .filter(({ reasoningType }) => reasoningType === "none")
       .map(({ content }) => content)
       .join("");

--- a/packages/lms-client/src/llm/OngoingPrediction.ts
+++ b/packages/lms-client/src/llm/OngoingPrediction.ts
@@ -57,10 +57,12 @@ export class OngoingPrediction<TStructuredOutputType = unknown> extends Streamab
   protected override async collect(fragments: ReadonlyArray<LLMPredictionFragment>) {
     const content = fragments.map(({ content }) => content).join("");
     const reasoningContent = fragments
+      .filter(({ isStructural }) => !isStructural)
       .filter(({ reasoningType }) => reasoningType === "reasoning")
       .map(({ content }) => content)
       .join("");
     const nonReasoningContent = fragments
+      .filter(({ isStructural }) => !isStructural)
       .filter(({ reasoningType }) => reasoningType === "none")
       .map(({ content }) => content)
       .join("");

--- a/packages/lms-client/src/llm/act.ts
+++ b/packages/lms-client/src/llm/act.ts
@@ -913,10 +913,12 @@ export async function internalAct<TPredictionResult, TEndPacket>(
           { roundIndex: predictionsPerformed, ...fragment },
         ]);
         contentArray.push(fragment.content);
-        if (fragment.reasoningType === "reasoning") {
-          reasoningContentArray.push(fragment.content);
-        } else {
-          nonReasoningContentArray.push(fragment.content);
+        if (!fragment.isStructural) {
+          if (fragment.reasoningType === "reasoning") {
+            reasoningContentArray.push(fragment.content);
+          } else {
+            nonReasoningContentArray.push(fragment.content);
+          }
         }
       },
       handlePromptProcessingProgress: progress => {

--- a/packages/lms-shared-types/src/ModelInfoBase.ts
+++ b/packages/lms-shared-types/src/ModelInfoBase.ts
@@ -3,6 +3,7 @@ import {
   modelCompatibilityTypeSchema,
   type ModelCompatibilityType,
 } from "./ModelCompatibilityType.js";
+import { quantizationSchema, type Quantization } from "./Quantization.js";
 
 /**
  * Represents info of a model that is downloaded and sits on the disk. This is the base type shared
@@ -36,9 +37,13 @@ export interface ModelInfoBase {
    */
   paramsString?: string;
   /**
-   * The architecture of the model.
+   * The architecture of the model. May not always be available.
    */
   architecture?: string;
+  /**
+   * The quantization of the model. May not always be available.
+   */
+  quantization?: Quantization;
 }
 export const modelInfoBaseSchema = z.object({
   modelKey: z.string(),
@@ -48,6 +53,7 @@ export const modelInfoBaseSchema = z.object({
   sizeBytes: z.number().int(),
   paramsString: z.string().optional(),
   architecture: z.string().optional(),
+  quantization: quantizationSchema.optional(),
 });
 
 /**

--- a/packages/lms-shared-types/src/Quantization.ts
+++ b/packages/lms-shared-types/src/Quantization.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+
+/**
+ * Represents the quantization of a model.
+ *
+ * @public
+ */
+export type Quantization = {
+  /**
+   * Name of the quantization.
+   */
+  name: string;
+  /**
+   * Roughly how many bits this quantization uses per value. This is not accurate and can vary from
+   * the actual BPW (bits per weight) of the quantization. Gives a rough idea of the
+   * quantization level.
+   */
+  bits: number;
+};
+export const quantizationSchema = z.object({
+  name: z.string(),
+  bits: z.number().int(),
+});

--- a/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
+++ b/packages/lms-shared-types/src/llm/LLMPredictionStats.ts
@@ -46,6 +46,7 @@ export const llmPredictionStatsSchema = z.object({
   tokensPerSecond: z.number().optional(),
   numGpuLayers: z.number().optional(),
   timeToFirstTokenSec: z.number().optional(),
+  totalTimeSec: z.number().optional(),
   promptTokensCount: z.number().int().optional(),
   predictedTokensCount: z.number().int().optional(),
   totalTokensCount: z.number().int().optional(),
@@ -93,6 +94,10 @@ export interface LLMPredictionStats {
    * The time it took to predict the first token in seconds.
    */
   timeToFirstTokenSec?: number;
+  /**
+   * The total time it took to predict the result in seconds.
+   */
+  totalTimeSec?: number;
   /**
    * The number of tokens that were supplied.
    */


### PR DESCRIPTION
- Filter out structural tags `<|channel|>`, `<|end|>` etc from the parsed content (reasoningContent and nonReasoningContent) 
- Return quantization info in model info
- Add total generation time to prediction stats