### PR TITLE
Makes plugin process read the baseUrl so the LM Studio instance it connects to can be configured

### DIFF
--- a/packages/lms-es-plugin-runner/src/generateEntryFile.ts
+++ b/packages/lms-es-plugin-runner/src/generateEntryFile.ts
@@ -6,10 +6,12 @@ declare var process: any;
 // We receive runtime information in the environment variables.
 const clientIdentifier = process.env.LMS_PLUGIN_CLIENT_IDENTIFIER;
 const clientPasskey = process.env.LMS_PLUGIN_CLIENT_PASSKEY;
+const baseUrl = process.env.LMS_PLUGIN_BASE_URL;
 
 const client = new LMStudioClient({
   clientIdentifier,
   clientPasskey,
+  baseUrl,
 });
 
 (globalThis as any).__LMS_PLUGIN_CONTEXT = true;


### PR DESCRIPTION
We now read the baseUrl from the environment variable. If not set, it just runs as normal as it will be undefined and default value will be applied.