### PR TITLE
Update heavy tests to contain new fields

### DIFF
--- a/packages/lms-client/src/embedding/.test-snapshots/EmbeddingModel.heavy.test.ts.snap
+++ b/packages/lms-client/src/embedding/.test-snapshots/EmbeddingModel.heavy.test.ts.snap
@@ -50,6 +50,10 @@ exports[`EmbeddingModel can get model info 1`] = `
   "maxContextLength": 2048,
   "modelKey": Any<String>,
   "path": "nomic-ai/nomic-embed-text-v1.5-GGUF/nomic-embed-text-v1.5.Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 84106624,
   "type": "embedding",
 }

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.act.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.act.heavy.test.ts.snap
@@ -12,6 +12,10 @@ exports[`LLM.act should call the tool with the correct parameters 1`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -23,11 +27,12 @@ exports[`LLM.act should call the tool with the correct parameters 2`] = `
 {
   "numGpuLayers": Any<Number>,
   "predictedTokensCount": 38,
-  "promptTokensCount": 192,
+  "promptTokensCount": 201,
   "stopReason": "eosFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
-  "totalTokensCount": 230,
+  "totalTimeSec": Any<Number>,
+  "totalTokensCount": 239,
 }
 `;
 
@@ -43,6 +48,10 @@ exports[`LLM.act should call the tool with the correct parameters 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -53,11 +62,12 @@ exports[`LLM.act should call the tool with the correct parameters 3`] = `
 exports[`LLM.act should call the tool with the correct parameters 4`] = `
 {
   "numGpuLayers": Any<Number>,
-  "predictedTokensCount": 13,
-  "promptTokensCount": 249,
+  "predictedTokensCount": 23,
+  "promptTokensCount": 258,
   "stopReason": "eosFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
-  "totalTokensCount": 262,
+  "totalTimeSec": Any<Number>,
+  "totalTokensCount": 281,
 }
 `;

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.complete.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.complete.heavy.test.ts.snap
@@ -6,6 +6,7 @@ exports[`LLM.complete should call onPredictionFragment 1`] = `
     {
       "containsDrafted": false,
       "content": "4",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -14,6 +15,7 @@ exports[`LLM.complete should call onPredictionFragment 1`] = `
     {
       "containsDrafted": false,
       "content": ";",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -91,6 +93,7 @@ exports[`LLM.complete should work with streaming 1`] = `
   {
     "containsDrafted": false,
     "content": "4",
+    "isStructural": false,
     "reasoningType": "none",
     "tokensCount": 1,
   },
@@ -105,6 +108,7 @@ exports[`LLM.complete should work with streaming 2`] = `
   "stopReason": "stopStringFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 16,
 }
 `;
@@ -121,6 +125,10 @@ exports[`LLM.complete should work with streaming 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -136,6 +144,7 @@ exports[`LLM.complete should work without streaming 2`] = `
   "stopReason": "stopStringFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 16,
 }
 `;
@@ -152,6 +161,10 @@ exports[`LLM.complete should work without streaming 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.heavy.test.ts.snap
@@ -59,6 +59,10 @@ exports[`LLM can get model info 1`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.respond.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.respond.heavy.test.ts.snap
@@ -6,6 +6,7 @@ exports[`LLM.respond should call onPredictionFragment callback 1`] = `
     {
       "containsDrafted": false,
       "content": "Assistant",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -14,6 +15,7 @@ exports[`LLM.respond should call onPredictionFragment callback 1`] = `
     {
       "containsDrafted": false,
       "content": " message",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -22,6 +24,7 @@ exports[`LLM.respond should call onPredictionFragment callback 1`] = `
     {
       "containsDrafted": false,
       "content": " ",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -30,6 +33,7 @@ exports[`LLM.respond should call onPredictionFragment callback 1`] = `
     {
       "containsDrafted": false,
       "content": "2",
+      "isStructural": false,
       "reasoningType": "none",
       "tokensCount": 1,
     },
@@ -108,6 +112,7 @@ exports[`LLM.respond should work with array of messages input 2`] = `
   "stopReason": "eosFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 46,
 }
 `;
@@ -124,6 +129,10 @@ exports[`LLM.respond should work with array of messages input 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -139,6 +148,7 @@ exports[`LLM.respond should work with single string input 2`] = `
   "stopReason": "maxPredictedTokensReached",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 43,
 }
 `;
@@ -155,6 +165,10 @@ exports[`LLM.respond should work with single string input 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -167,24 +181,28 @@ exports[`LLM.respond should work with streaming 1`] = `
   {
     "containsDrafted": false,
     "content": "Assistant",
+    "isStructural": false,
     "reasoningType": "none",
     "tokensCount": 1,
   },
   {
     "containsDrafted": false,
     "content": " message",
+    "isStructural": false,
     "reasoningType": "none",
     "tokensCount": 1,
   },
   {
     "containsDrafted": false,
     "content": " ",
+    "isStructural": false,
     "reasoningType": "none",
     "tokensCount": 1,
   },
   {
     "containsDrafted": false,
     "content": "2",
+    "isStructural": false,
     "reasoningType": "none",
     "tokensCount": 1,
   },
@@ -201,6 +219,7 @@ exports[`LLM.respond should work with streaming 3`] = `
   "stopReason": "eosFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 46,
 }
 `;
@@ -217,6 +236,10 @@ exports[`LLM.respond should work with streaming 4`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",
@@ -232,6 +255,7 @@ exports[`LLM.respond should work without streaming 2`] = `
   "stopReason": "eosFound",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 46,
 }
 `;
@@ -248,6 +272,10 @@ exports[`LLM.respond should work without streaming 3`] = `
   "modelKey": Any<String>,
   "paramsString": "0.5B",
   "path": "lmstudio-community/Qwen2.5-0.5B-Instruct-GGUF/Qwen2.5-0.5B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 397807936,
   "trainedForToolUse": true,
   "type": "llm",

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.speculativeDecoding.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.speculativeDecoding.heavy.test.ts.snap
@@ -12,6 +12,7 @@ exports[`LLM + speculative decoding should work with .complete 2`] = `
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
   "totalDraftTokensCount": 3,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 20,
   "usedDraftModelKey": Any<String>,
 }
@@ -29,6 +30,10 @@ exports[`LLM + speculative decoding should work with .complete 3`] = `
   "modelKey": Any<String>,
   "paramsString": "3B",
   "path": "lmstudio-community/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 1929903008,
   "trainedForToolUse": true,
   "type": "llm",
@@ -50,6 +55,7 @@ exports[`LLM + speculative decoding should work with .respond 2`] = `
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
   "totalDraftTokensCount": 7,
+  "totalTimeSec": Any<Number>,
   "totalTokensCount": 46,
   "usedDraftModelKey": Any<String>,
 }
@@ -67,6 +73,10 @@ exports[`LLM + speculative decoding should work with .respond 3`] = `
   "modelKey": Any<String>,
   "paramsString": "3B",
   "path": "lmstudio-community/Qwen2.5-3B-Instruct-GGUF/Qwen2.5-3B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 1929903008,
   "trainedForToolUse": true,
   "type": "llm",

--- a/packages/lms-client/src/llm/.test-snapshots/LLM.vision.heavy.test.ts.snap
+++ b/packages/lms-client/src/llm/.test-snapshots/LLM.vision.heavy.test.ts.snap
@@ -1,16 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`LLM with vision should work with base64 upload 1`] = `"I see the W3C logo, which"`;
+exports[`LLM with vision should work with base64 upload 1`] = `"I see the logo for W3C,"`;
 
 exports[`LLM with vision should work with base64 upload 2`] = `
 {
   "numGpuLayers": Any<Number>,
   "predictedTokensCount": 10,
-  "promptTokensCount": 27,
+  "promptTokensCount": 25,
   "stopReason": "maxPredictedTokensReached",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
-  "totalTokensCount": 37,
+  "totalTimeSec": Any<Number>,
+  "totalTokensCount": 35,
 }
 `;
 
@@ -26,6 +27,10 @@ exports[`LLM with vision should work with base64 upload 3`] = `
   "modelKey": Any<String>,
   "paramsString": "2B",
   "path": "lmstudio-community/Qwen2-VL-2B-Instruct-GGUF/Qwen2-VL-2B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 3647162336,
   "trainedForToolUse": false,
   "type": "llm",
@@ -33,17 +38,18 @@ exports[`LLM with vision should work with base64 upload 3`] = `
 }
 `;
 
-exports[`LLM with vision should work with file upload 1`] = `"I see the W3C logo, which"`;
+exports[`LLM with vision should work with file upload 1`] = `"I see the logo for W3C,"`;
 
 exports[`LLM with vision should work with file upload 2`] = `
 {
   "numGpuLayers": Any<Number>,
   "predictedTokensCount": 10,
-  "promptTokensCount": 27,
+  "promptTokensCount": 25,
   "stopReason": "maxPredictedTokensReached",
   "timeToFirstTokenSec": Any<Number>,
   "tokensPerSecond": Any<Number>,
-  "totalTokensCount": 37,
+  "totalTimeSec": Any<Number>,
+  "totalTokensCount": 35,
 }
 `;
 
@@ -59,6 +65,10 @@ exports[`LLM with vision should work with file upload 3`] = `
   "modelKey": Any<String>,
   "paramsString": "2B",
   "path": "lmstudio-community/Qwen2-VL-2B-Instruct-GGUF/Qwen2-VL-2B-Instruct-Q4_K_M.gguf",
+  "quantization": {
+    "bits": 4,
+    "name": "Q4_K_M",
+  },
   "sizeBytes": 3647162336,
   "trainedForToolUse": false,
   "type": "llm",

--- a/packages/lms-client/src/llm/LLM.act.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.act.heavy.test.ts
@@ -81,6 +81,7 @@ describe("LLM.act", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     const prediction1 = onPredictionCompleted.mock.calls[1][0] as PredictionResult;
     expect(prediction1.content).toContain("4");
@@ -94,6 +95,7 @@ describe("LLM.act", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
 
     // Cannot assert on content due to non-determinism
@@ -265,7 +267,7 @@ describe("LLM.act", () => {
     const onToolCallRequestNameReceived = jest.fn();
     const onToolCallRequestArgumentFragmentGenerated = jest.fn();
 
-    await model.act('First say "Hi". Then calculate 1 + 3 with the tool.', [unimplementedAddTool], {
+    await model.act("Please calculate 1 + 3 with the tool.", [unimplementedAddTool], {
       onToolCallRequestNameReceived,
       onToolCallRequestArgumentFragmentGenerated,
     });

--- a/packages/lms-client/src/llm/LLM.complete.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.complete.heavy.test.ts
@@ -30,6 +30,7 @@ describe("LLM.complete", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),
@@ -55,6 +56,7 @@ describe("LLM.complete", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),

--- a/packages/lms-client/src/llm/LLM.respond.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.respond.heavy.test.ts
@@ -35,6 +35,7 @@ describe("LLM.respond", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),
@@ -61,6 +62,7 @@ describe("LLM.respond", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),
@@ -141,6 +143,7 @@ describe("LLM.respond", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),
@@ -167,6 +170,7 @@ describe("LLM.respond", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),

--- a/packages/lms-client/src/llm/LLM.speculativeDecoding.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.speculativeDecoding.heavy.test.ts
@@ -37,6 +37,7 @@ describe("LLM + speculative decoding", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
       usedDraftModelKey: expect.any(String),
     });
     expect(result.modelInfo).toMatchSnapshot({
@@ -58,6 +59,7 @@ describe("LLM + speculative decoding", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
       usedDraftModelKey: expect.any(String),
     });
     expect(result.modelInfo).toMatchSnapshot({

--- a/packages/lms-client/src/llm/LLM.vision.heavy.test.ts
+++ b/packages/lms-client/src/llm/LLM.vision.heavy.test.ts
@@ -47,6 +47,7 @@ describe("LLM with vision", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),
@@ -69,6 +70,7 @@ describe("LLM with vision", () => {
       numGpuLayers: expect.any(Number),
       timeToFirstTokenSec: expect.any(Number),
       tokensPerSecond: expect.any(Number),
+      totalTimeSec: expect.any(Number),
     });
     expect(result.modelInfo).toMatchSnapshot({
       identifier: expect.any(String),


### PR DESCRIPTION
We added new fields such as `quantization` and `isStructural`. Added them to the heavy tests.

(heavy tests are still kinda flaky as it is hardware/engine dependent. We should eventually improve them, but just fix the snapshots for now so it doesn't block release.)