### PR TITLE
Fix GPUSettingSchema for CPU MoE

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
+++ b/packages/lms-shared-types/src/llm/LLMLoadModelConfig.ts
@@ -62,6 +62,7 @@ export type GPUSetting = {
 };
 export const gpuSettingSchema = z.object({
   ratio: llmLlamaAccelerationOffloadRatioSchema.optional(),
+  numCpuExpertLayersRatio: llmLlamaAccelerationOffloadRatioSchema.optional(),
   mainGpu: z.number().int().optional(),
   splitStrategy: llmSplitStrategySchema.optional(),
   disabledGpus: z.array(z.number().int()).optional(),


### PR DESCRIPTION
I forgot to do this last time so setting CPU MoE overrides via the SDK wasn't working. This fixes it.