### PR TITLE
Rugved/cli esm

### DIFF
--- a/publish/cli/injectVariables.js
+++ b/publish/cli/injectVariables.js
@@ -1,8 +1,12 @@
 // Inject the current version by replacing the magic string <LMS-CLI-CURRENT-VERSION>
 // This is much faster than rollup-plugin-replace
 
-const { readFileSync, writeFileSync } = require("fs");
-const { join } = require("path");
+import { readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = new URL(".", import.meta.url).pathname;
 
 const content = readFileSync(join(__dirname, "dist", "index.js"), "utf-8");
 const packageJson = readFileSync(join(__dirname, "package.json"), "utf-8");

--- a/publish/cli/injectVariables.js
+++ b/publish/cli/injectVariables.js
@@ -3,9 +3,7 @@
 
 import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
-import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url);
 const __dirname = new URL(".", import.meta.url).pathname;
 
 const content = readFileSync(join(__dirname, "dist", "index.js"), "utf-8");

--- a/publish/cli/package.json
+++ b/publish/cli/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.47",
   "description": "LM Studio CLI",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "build-rollup": "rollup -c",
     "build-inject-variables": "node ./injectVariables.js",

--- a/publish/cli/rollup.config.js
+++ b/publish/cli/rollup.config.js
@@ -33,9 +33,4 @@ export default {
     json(),
     banner(() => "#!/usr/bin/env node\n"),
   ],
-  external: [],
-  onwarn(warning, warn) {
-    if (warning.code === "UNRESOLVED_IMPORT" && warning.id === "react-devtools-core") return;
-    warn(warning);
-  },
 };

--- a/publish/cli/rollup.config.js
+++ b/publish/cli/rollup.config.js
@@ -4,9 +4,7 @@ import commonjs from "@rollup/plugin-commonjs";
 import json from "@rollup/plugin-json";
 import replace from "@rollup/plugin-replace";
 import banner from "rollup-plugin-banner2";
-import { fileURLToPath } from "url";
 
-const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export default {
@@ -37,8 +35,6 @@ export default {
   ],
   external: [],
   onwarn(warning, warn) {
-    // Suppress circular dependency warnings and unresolved dependency warnings
-    if (warning.code === "CIRCULAR_DEPENDENCY") return;
     if (warning.code === "UNRESOLVED_IMPORT" && warning.id === "react-devtools-core") return;
     warn(warning);
   },


### PR DESCRIPTION
## Overview

attempt to convert the CLI to a ESM module instead of CJS which allows to use `ink` and newer version of `inquirer` in `lms-cli`