### PR TITLE
Allow arbitrary additionalProperties in JSON schema

### DIFF
--- a/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
+++ b/packages/lms-shared-types/src/llm/LLMToolUseSetting.ts
@@ -10,7 +10,7 @@ export type LLMToolParameters = {
   type: "object";
   properties: Record<string, any>;
   required?: string[];
-  additionalProperties?: boolean;
+  additionalProperties?: any;
   $defs?: Record<string, any>;
 };
 
@@ -19,7 +19,7 @@ export const llmToolParametersSchema = z.discriminatedUnion("type", [
     type: z.literal("object"),
     properties: z.record(jsonSerializableSchema),
     required: z.array(z.string()).optional(),
-    additionalProperties: z.boolean().optional(),
+    additionalProperties: z.any().optional(),
     $defs: z.record(jsonSerializableSchema).optional(),
   }),
   // add more parameter types here


### PR DESCRIPTION
Fixes #230

`additionalProperties` can also be arbitrary schema that validates against every extra value, not just boolean (https://json-schema.org/understanding-json-schema/reference/object#additionalproperties). This PR relaxes such requirement.

There are no logic changes required as we pass the schema to `jsonschema` for parsing, which will already recognize the field: https://github.com/lmstudio-ai/lmstudio-js/blob/main/packages/lms-client/src/llm/tool.ts#L358

Also, this PR used `any` for the field since we are not modeling the exact types of a json schema and are just treating them as "blob of arbitrary json".