### PR TITLE
[.act] Don't append tool call result for unimplemented tool

### DIFF
--- a/packages/lms-client/src/llm/act.ts
+++ b/packages/lms-client/src/llm/act.ts
@@ -1131,33 +1131,33 @@ export async function internalAct<TPredictionResult, TEndPacket>(
               let result: any;
               try {
                 result = await tool.implementation(pushedRequest.arguments ?? {}, toolCallContext);
+                let resultString: string;
+                if (result === undefined) {
+                  resultString = "undefined";
+                } else {
+                  try {
+                    resultString = JSON.stringify(result);
+                  } catch (error) {
+                    throw makePrettyError(
+                      `Return value of tool ${tool.name} cannot be converted to JSON.`,
+                      stack,
+                    );
+                  }
+                }
+                toolCallResults.push({
+                  index: toolCallIndex,
+                  data: {
+                    type: "toolCallResult",
+                    toolCallId: request.id,
+                    content: resultString,
+                  },
+                });
               } catch (error: any) {
                 if (!(error instanceof UnimplementedToolError)) {
                   throw error;
                 }
                 hasCalledUnimplementedTool = true;
               }
-              let resultString: string;
-              if (result === undefined) {
-                resultString = "undefined";
-              } else {
-                try {
-                  resultString = JSON.stringify(result);
-                } catch (error) {
-                  throw makePrettyError(
-                    `Return value of tool ${tool.name} cannot be converted to JSON.`,
-                    stack,
-                  );
-                }
-              }
-              toolCallResults.push({
-                index: toolCallIndex,
-                data: {
-                  type: "toolCallResult",
-                  toolCallId: request.id,
-                  content: resultString,
-                },
-              });
             }, abortController.signal)
             .catch(finalReject),
         );


### PR DESCRIPTION
`onMessage` is currently being called with a tool result message that looks like:
```
{"role":"tool","content":[{"type":"toolCallResult","content":"undefined","toolCallId":"162305404"}
```
for unimplemented tools.

We shouldn't be returning any tool results for unimplemented tools. Fix this by moving the result handling to only happen if the `tool.implementation` and other logic after implementation is called doesn't throw.