### PR TITLE
Add ability to fetch load and prediction configs

### DIFF
--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -156,7 +156,7 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
     const stack = getCurrentStack(1);
     const loadConfig = await this.getLoadKVConfig(stack);
     return kvConfigToEmbeddingLoadModelConfig(loadConfig, {
-      notPartial: true,
+      useDefaultsForMissingKeys: true,
     });
   }
 }

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -155,6 +155,8 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
   public async getLoadConfig(): Promise<EmbeddingLoadModelConfig> {
     const stack = getCurrentStack(1);
     const loadConfig = await this.getLoadKVConfig(stack);
-    return kvConfigToEmbeddingLoadModelConfig(loadConfig, true);
+    return kvConfigToEmbeddingLoadModelConfig(loadConfig, {
+      notPartial: true,
+    });
   }
 }

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -155,6 +155,6 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
   public async getLoadConfig(): Promise<EmbeddingLoadModelConfig> {
     const stack = getCurrentStack(1);
     const loadConfig = await this.getLoadKVConfig(stack);
-    return kvConfigToEmbeddingLoadModelConfig(loadConfig);
+    return kvConfigToEmbeddingLoadModelConfig(loadConfig, true);
   }
 }

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -3,8 +3,13 @@ import { type EmbeddingPort } from "@lmstudio/lms-external-backend-interfaces";
 import {
   embeddingSharedLoadConfigSchematics,
   globalConfigSchematics,
+  kvConfigToEmbeddingLoadModelConfig,
 } from "@lmstudio/lms-kv-config";
-import { type EmbeddingModelInstanceInfo, type ModelSpecifier } from "@lmstudio/lms-shared-types";
+import {
+  type EmbeddingLoadModelConfig,
+  type EmbeddingModelInstanceInfo,
+  type ModelSpecifier,
+} from "@lmstudio/lms-shared-types";
 import { z } from "zod";
 import { DynamicHandle } from "../modelShared/DynamicHandle.js";
 
@@ -145,5 +150,11 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
         { stack },
       )
     ).tokenCount;
+  }
+
+  public async getLoadConfig(): Promise<EmbeddingLoadModelConfig> {
+    const stack = getCurrentStack(1);
+    const loadConfig = await this.getLoadKVConfig(stack);
+    return kvConfigToEmbeddingLoadModelConfig(loadConfig);
   }
 }

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -79,13 +79,13 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
 
   public async getContextLength(): Promise<number> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadConfig(stack);
+    const loadConfig = await this.getLoadKVConfig(stack);
     return embeddingSharedLoadConfigSchematics.access(loadConfig, "contextLength");
   }
 
   public async getEvalBatchSize(): Promise<number> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadConfig(stack);
+    const loadConfig = await this.getLoadKVConfig(stack);
     return globalConfigSchematics.access(loadConfig, "embedding.load.llama.evalBatchSize");
   }
 

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -154,7 +154,7 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
 
   public async getLoadConfig(): Promise<EmbeddingLoadModelConfig> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadKVConfig(stack);
+    const loadConfig = await super.getLoadKVConfig(stack);
     return kvConfigToEmbeddingLoadModelConfig(loadConfig, {
       useDefaultsForMissingKeys: true,
     });

--- a/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
+++ b/packages/lms-client/src/embedding/EmbeddingDynamicHandle.ts
@@ -84,13 +84,13 @@ export class EmbeddingDynamicHandle extends DynamicHandle<
 
   public async getContextLength(): Promise<number> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadKVConfig(stack);
+    const loadConfig = await super.getLoadKVConfig(stack);
     return embeddingSharedLoadConfigSchematics.access(loadConfig, "contextLength");
   }
 
   public async getEvalBatchSize(): Promise<number> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadKVConfig(stack);
+    const loadConfig = await super.getLoadKVConfig(stack);
     return globalConfigSchematics.access(loadConfig, "embedding.load.llama.evalBatchSize");
   }
 

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -1215,7 +1215,7 @@ export class LLMDynamicHandle extends DynamicHandle<
 
   /**
    * Get the base prediction configuration for the model. This does not include any overrides that
-   * may be provided during prediction time.
+   * may be provided at prediction time.
    */
   public async getBasePredictionConfig(): Promise<LLMPredictionConfig> {
     const stack = getCurrentStack(1);

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -1209,7 +1209,7 @@ export class LLMDynamicHandle extends DynamicHandle<
     const stack = getCurrentStack(1);
     const loadConfig = await super.getLoadKVConfig(stack);
     return kvConfigToLLMLoadModelConfig(loadConfig, {
-      notPartial: true,
+      useDefaultsForMissingKeys: true,
     });
   }
 
@@ -1226,7 +1226,7 @@ export class LLMDynamicHandle extends DynamicHandle<
       basePredictionConfig,
     );
     return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack), {
-      notPartial: true,
+      useDefaultsForMissingKeys: true,
     });
   }
 }

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -1208,7 +1208,7 @@ export class LLMDynamicHandle extends DynamicHandle<
   public async getLoadConfig(): Promise<LLMLoadModelConfig> {
     const stack = getCurrentStack(1);
     const loadConfig = await super.getLoadKVConfig(stack);
-    return kvConfigToLLMLoadModelConfig(loadConfig);
+    return kvConfigToLLMLoadModelConfig(loadConfig, true);
   }
 
   /**
@@ -1223,6 +1223,6 @@ export class LLMDynamicHandle extends DynamicHandle<
       "apiOverride",
       basePredictionConfig,
     );
-    return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack));
+    return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack), true);
   }
 }

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -1208,7 +1208,9 @@ export class LLMDynamicHandle extends DynamicHandle<
   public async getLoadConfig(): Promise<LLMLoadModelConfig> {
     const stack = getCurrentStack(1);
     const loadConfig = await super.getLoadKVConfig(stack);
-    return kvConfigToLLMLoadModelConfig(loadConfig, true);
+    return kvConfigToLLMLoadModelConfig(loadConfig, {
+      notPartial: true,
+    });
   }
 
   /**
@@ -1223,6 +1225,8 @@ export class LLMDynamicHandle extends DynamicHandle<
       "apiOverride",
       basePredictionConfig,
     );
-    return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack), true);
+    return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack), {
+      notPartial: true,
+    });
   }
 }

--- a/packages/lms-client/src/llm/LLMDynamicHandle.ts
+++ b/packages/lms-client/src/llm/LLMDynamicHandle.ts
@@ -11,6 +11,9 @@ import {
 import { type LLMPort } from "@lmstudio/lms-external-backend-interfaces";
 import {
   addKVConfigToStack,
+  collapseKVStack,
+  kvConfigToLLMLoadModelConfig,
+  kvConfigToLLMPredictionConfig,
   llmPredictionConfigToKVConfig,
   llmSharedLoadConfigSchematics,
   llmSharedPredictionConfigSchematics,
@@ -23,6 +26,8 @@ import {
   type LLMApplyPromptTemplateOpts,
   llmApplyPromptTemplateOptsSchema,
   type LLMInstanceInfo,
+  type LLMLoadModelConfig,
+  type LLMPredictionConfig,
   type LLMPredictionConfigInput,
   llmPredictionConfigInputSchema,
   type LLMPredictionFragment,
@@ -1080,7 +1085,7 @@ export class LLMDynamicHandle extends DynamicHandle<
 
   public async getContextLength(): Promise<number> {
     const stack = getCurrentStack(1);
-    const loadConfig = await this.getLoadConfig(stack);
+    const loadConfig = await this.getLoadKVConfig(stack);
     return llmSharedLoadConfigSchematics.access(loadConfig, "contextLength");
   }
 
@@ -1195,5 +1200,29 @@ export class LLMDynamicHandle extends DynamicHandle<
       { specifier: this.specifier, draftModelKey },
       { stack },
     );
+  }
+
+  /**
+   * Get the configuration used to load the model.
+   */
+  public async getLoadConfig(): Promise<LLMLoadModelConfig> {
+    const stack = getCurrentStack(1);
+    const loadConfig = await super.getLoadKVConfig(stack);
+    return kvConfigToLLMLoadModelConfig(loadConfig);
+  }
+
+  /**
+   * Get the base prediction configuration for the model. This does not include any overrides that
+   * may be provided during prediction time.
+   */
+  public async getBasePredictionConfig(): Promise<LLMPredictionConfig> {
+    const stack = getCurrentStack(1);
+    const basePredictionConfig = await super.getBasePredictionKVConfig(stack);
+    const kvStack = addKVConfigToStack(
+      this.internalKVConfigStack,
+      "apiOverride",
+      basePredictionConfig,
+    );
+    return kvConfigToLLMPredictionConfig(collapseKVStack(kvStack));
   }
 }

--- a/packages/lms-client/src/modelShared/DynamicHandle.ts
+++ b/packages/lms-client/src/modelShared/DynamicHandle.ts
@@ -56,13 +56,31 @@ export abstract class DynamicHandle<
     return info;
   }
 
-  protected async getLoadConfig(stack: string): Promise<KVConfig> {
+  /**
+   * Gets the load configuration of the model instance associated with this `DynamicHandle`. Reason
+   * this function is called `getLoadKVConfig` instead of just `getLoadConfig` is to avoid conflict
+   * with the user-facing `getLoadConfig` in `LLMDynamicHandle` and `EmbeddingDynamicHandle`.
+   */
+  protected async getLoadKVConfig(stack: string): Promise<KVConfig> {
     const loadConfig = await this.port.callRpc(
       "getLoadConfig",
       { specifier: this.specifier },
       { stack },
     );
     return loadConfig;
+  }
+
+  /**
+   * Gets the base prediction configuration of the model instance associated with this
+   * `DynamicHandle`.
+   */
+  protected async getBasePredictionKVConfig(stack: string): Promise<KVConfig> {
+    const basePredictionConfig = await this.port.callRpc(
+      "getBasePredictionConfig",
+      { specifier: this.specifier },
+      { stack },
+    );
+    return basePredictionConfig;
   }
 
   /**

--- a/packages/lms-external-backend-interfaces/src/baseModelBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/baseModelBackendInterface.ts
@@ -91,6 +91,12 @@ export function createBaseModelBackendInterface<
       }),
       returns: kvConfigSchema,
     })
+    .addRpcEndpoint("getBasePredictionConfig", {
+      parameter: z.object({
+        specifier: modelSpecifierSchema,
+      }),
+      returns: kvConfigSchema,
+    })
     .addChannelEndpoint("getOrLoad", {
       creationParameter: z.object({
         identifier: z.string(),

--- a/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
@@ -7,9 +7,18 @@ import {
 import { collapseKVStackRaw } from "../KVConfig.js";
 import { embeddingLoadSchematics } from "../schema.js";
 
-export function kvConfigToEmbeddingLoadModelConfig(config: KVConfig): EmbeddingLoadModelConfig {
+export function kvConfigToEmbeddingLoadModelConfig(
+  config: KVConfig,
+  notPartial?: boolean,
+): EmbeddingLoadModelConfig {
   const result: EmbeddingLoadModelConfig = {};
-  const parsed = embeddingLoadSchematics.parse(config);
+
+  let parsed;
+  if (notPartial === true) {
+    parsed = embeddingLoadSchematics.parse(config);
+  } else {
+    parsed = embeddingLoadSchematics.parsePartial(config);
+  }
 
   const gpuSplitConfig = parsed.get("load.gpuSplitConfig");
   if (gpuSplitConfig !== undefined) {

--- a/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
@@ -1,0 +1,63 @@
+import {
+  convertGPUSettingToGPUSplitConfig,
+  convertGPUSplitConfigToGPUSetting,
+  type EmbeddingLoadModelConfig,
+  type KVConfig,
+} from "@lmstudio/lms-shared-types";
+import { collapseKVStackRaw } from "../KVConfig.js";
+import { embeddingLoadSchematics } from "../schema.js";
+
+export function kvConfigToEmbeddingLoadModelConfig(config: KVConfig): EmbeddingLoadModelConfig {
+  const result: EmbeddingLoadModelConfig = {};
+  const parsed = embeddingLoadSchematics.parse(config);
+
+  const gpuSplitConfig = parsed.get("load.gpuSplitConfig");
+  if (gpuSplitConfig !== undefined) {
+    const gpuSetting = convertGPUSplitConfigToGPUSetting(gpuSplitConfig);
+    result.gpu = gpuSetting;
+  }
+  const contextLength = parsed.get("contextLength");
+  if (contextLength !== undefined) {
+    result.contextLength = contextLength;
+  }
+  const ropeFrequencyBase = parsed.get("llama.ropeFrequencyBase");
+  if (ropeFrequencyBase !== undefined && ropeFrequencyBase.checked === true) {
+    result.ropeFrequencyBase = ropeFrequencyBase.value;
+  }
+
+  const ropeFrequencyScale = parsed.get("llama.ropeFrequencyScale");
+  if (ropeFrequencyScale !== undefined && ropeFrequencyScale.checked === true) {
+    result.ropeFrequencyScale = ropeFrequencyScale.value;
+  }
+
+  const keepModelInMemory = parsed.get("llama.keepModelInMemory");
+  if (keepModelInMemory !== undefined) {
+    result.keepModelInMemory = keepModelInMemory;
+  }
+
+  const tryMmap = parsed.get("llama.tryMmap");
+  if (tryMmap !== undefined) {
+    result.tryMmap = tryMmap;
+  }
+
+  return result;
+}
+
+export function embeddingLoadModelConfigToKVConfig(config: EmbeddingLoadModelConfig): KVConfig {
+  const top = embeddingLoadSchematics.buildPartialConfig({
+    "load.gpuSplitConfig": convertGPUSettingToGPUSplitConfig(config.gpu),
+    "contextLength": config.contextLength,
+    "llama.ropeFrequencyBase":
+      config.ropeFrequencyBase !== undefined
+        ? { value: config.ropeFrequencyBase, checked: true }
+        : undefined,
+    "llama.ropeFrequencyScale":
+      config.ropeFrequencyScale !== undefined
+        ? { value: config.ropeFrequencyScale, checked: true }
+        : undefined,
+
+    "llama.keepModelInMemory": config.keepModelInMemory,
+    "llama.tryMmap": config.tryMmap,
+  });
+  return collapseKVStackRaw([top]);
+}

--- a/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
@@ -7,9 +7,12 @@ import {
 import { collapseKVStackRaw } from "../KVConfig.js";
 import { embeddingLoadSchematics } from "../schema.js";
 
+interface KvConfigToEmbeddingLoadModelConfigOpts {
+  notPartial?: boolean;
+}
 export function kvConfigToEmbeddingLoadModelConfig(
   config: KVConfig,
-  notPartial?: boolean,
+  { notPartial }: KvConfigToEmbeddingLoadModelConfigOpts = {},
 ): EmbeddingLoadModelConfig {
   const result: EmbeddingLoadModelConfig = {};
 

--- a/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/embeddingLoadModelConfig.ts
@@ -8,16 +8,19 @@ import { collapseKVStackRaw } from "../KVConfig.js";
 import { embeddingLoadSchematics } from "../schema.js";
 
 interface KvConfigToEmbeddingLoadModelConfigOpts {
-  notPartial?: boolean;
+  /**
+   * Fills the missing keys passed in with default values
+   */
+  useDefaultsForMissingKeys?: boolean;
 }
 export function kvConfigToEmbeddingLoadModelConfig(
   config: KVConfig,
-  { notPartial }: KvConfigToEmbeddingLoadModelConfigOpts = {},
+  { useDefaultsForMissingKeys }: KvConfigToEmbeddingLoadModelConfigOpts = {},
 ): EmbeddingLoadModelConfig {
   const result: EmbeddingLoadModelConfig = {};
 
   let parsed;
-  if (notPartial === true) {
+  if (useDefaultsForMissingKeys === true) {
     parsed = embeddingLoadSchematics.parse(config);
   } else {
     parsed = embeddingLoadSchematics.parsePartial(config);

--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -7,9 +7,13 @@ import {
 import { collapseKVStackRaw } from "../KVConfig.js";
 import { llmLoadSchematics } from "../schema.js";
 
+interface KvConfigToLLMLoadModelConfigOpts {
+  notPartial?: boolean;
+}
+
 export function kvConfigToLLMLoadModelConfig(
   config: KVConfig,
-  notPartial?: boolean,
+  { notPartial }: KvConfigToLLMLoadModelConfigOpts = {},
 ): LLMLoadModelConfig {
   const result: LLMLoadModelConfig = {};
 

--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -1,0 +1,126 @@
+import {
+  convertGPUSettingToGPUSplitConfig,
+  convertGPUSplitConfigToGPUSetting,
+  type KVConfig,
+  type LLMLoadModelConfig,
+} from "@lmstudio/lms-shared-types";
+import { collapseKVStackRaw } from "../KVConfig.js";
+import { llmLoadSchematics } from "../schema.js";
+
+export function kvConfigToLLMLoadModelConfig(config: KVConfig): LLMLoadModelConfig {
+  const result: LLMLoadModelConfig = {};
+  const parsed = llmLoadSchematics.parse(config);
+
+  const gpuSplitConfig = parsed.get("gpuSplitConfig");
+  if (gpuSplitConfig !== undefined) {
+    const gpuSetting = convertGPUSplitConfigToGPUSetting(gpuSplitConfig);
+    result.gpu = gpuSetting;
+  }
+
+  const gpuStrictVramCap = parsed.get("gpuStrictVramCap");
+  if (gpuStrictVramCap !== undefined) {
+    result.gpuStrictVramCap = gpuStrictVramCap;
+  }
+
+  const offloadKVCacheToGpu = parsed.get("offloadKVCacheToGpu");
+  if (offloadKVCacheToGpu !== undefined) {
+    result.offloadKVCacheToGpu = offloadKVCacheToGpu;
+  }
+
+  const contextLength = parsed.get("contextLength");
+  if (contextLength !== undefined) {
+    result.contextLength = contextLength;
+  }
+
+  const ropeFrequencyBase = parsed.get("llama.ropeFrequencyBase");
+  if (ropeFrequencyBase !== undefined && ropeFrequencyBase.checked === true) {
+    result.ropeFrequencyBase = ropeFrequencyBase.value;
+  }
+
+  const ropeFrequencyScale = parsed.get("llama.ropeFrequencyScale");
+  if (ropeFrequencyScale !== undefined && ropeFrequencyScale.checked === true) {
+    result.ropeFrequencyScale = ropeFrequencyScale.value;
+  }
+
+  const evalBatchSize = parsed.get("llama.evalBatchSize");
+  if (evalBatchSize !== undefined) {
+    result.evalBatchSize = evalBatchSize;
+  }
+
+  const flashAttention = parsed.get("llama.flashAttention");
+  if (flashAttention !== undefined) {
+    result.flashAttention = flashAttention;
+  }
+
+  const keepModelInMemory = parsed.get("llama.keepModelInMemory");
+  if (keepModelInMemory !== undefined) {
+    result.keepModelInMemory = keepModelInMemory;
+  }
+
+  const seed = parsed.get("seed");
+  if (seed !== undefined && seed.checked === true) {
+    result.seed = seed.value;
+  }
+
+  const useFp16ForKVCache = parsed.get("llama.useFp16ForKVCache");
+  if (useFp16ForKVCache !== undefined) {
+    result.useFp16ForKVCache = useFp16ForKVCache;
+  }
+
+  const tryMmap = parsed.get("llama.tryMmap");
+  if (tryMmap !== undefined) {
+    result.tryMmap = tryMmap;
+  }
+
+  const numExperts = parsed.get("numExperts");
+  if (numExperts !== undefined) {
+    result.numExperts = numExperts;
+  }
+
+  const llamaKCacheQuantizationType = parsed.get("llama.kCacheQuantizationType");
+  if (llamaKCacheQuantizationType !== undefined && llamaKCacheQuantizationType.checked === true) {
+    result.llamaKCacheQuantizationType = llamaKCacheQuantizationType.value;
+  }
+
+  const llamaVCacheQuantizationType = parsed.get("llama.vCacheQuantizationType");
+  if (llamaVCacheQuantizationType !== undefined && llamaVCacheQuantizationType.checked === true) {
+    result.llamaVCacheQuantizationType = llamaVCacheQuantizationType.value;
+  }
+
+  return result;
+}
+
+export function llmLoadModelConfigToKVConfig(config: LLMLoadModelConfig): KVConfig {
+  const top = llmLoadSchematics.buildPartialConfig({
+    "gpuSplitConfig": convertGPUSettingToGPUSplitConfig(config.gpu),
+    "gpuStrictVramCap": config.gpuStrictVramCap,
+    "offloadKVCacheToGpu": config.offloadKVCacheToGpu,
+    "contextLength": config.contextLength,
+    "llama.ropeFrequencyBase":
+      config.ropeFrequencyBase !== undefined
+        ? { value: config.ropeFrequencyBase, checked: true }
+        : undefined,
+    "llama.ropeFrequencyScale":
+      config.ropeFrequencyScale !== undefined
+        ? { value: config.ropeFrequencyScale, checked: true }
+        : undefined,
+    "llama.evalBatchSize": config.evalBatchSize,
+    "llama.flashAttention": config.flashAttention,
+    "llama.keepModelInMemory": config.keepModelInMemory,
+    "seed": config.seed !== undefined ? { value: config.seed, checked: true } : undefined,
+    "llama.useFp16ForKVCache": config.useFp16ForKVCache,
+    "llama.tryMmap": config.tryMmap,
+    "numExperts": config.numExperts,
+    "llama.kCacheQuantizationType":
+      config.llamaKCacheQuantizationType !== undefined &&
+      config.llamaKCacheQuantizationType !== false
+        ? { value: config.llamaKCacheQuantizationType, checked: true }
+        : undefined,
+    "llama.vCacheQuantizationType":
+      config.llamaVCacheQuantizationType !== undefined &&
+      config.llamaVCacheQuantizationType !== false
+        ? { value: config.llamaVCacheQuantizationType, checked: true }
+        : undefined,
+  });
+  return collapseKVStackRaw([top]);
+}

--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -8,17 +8,20 @@ import { collapseKVStackRaw } from "../KVConfig.js";
 import { llmLoadSchematics } from "../schema.js";
 
 interface KvConfigToLLMLoadModelConfigOpts {
-  notPartial?: boolean;
+  /**
+   * Fills the missing keys passed in with default values
+   */
+  useDefaultsForMissingKeys?: boolean;
 }
 
 export function kvConfigToLLMLoadModelConfig(
   config: KVConfig,
-  { notPartial }: KvConfigToLLMLoadModelConfigOpts = {},
+  { useDefaultsForMissingKeys }: KvConfigToLLMLoadModelConfigOpts = {},
 ): LLMLoadModelConfig {
   const result: LLMLoadModelConfig = {};
 
   let parsed;
-  if (notPartial === true) {
+  if (useDefaultsForMissingKeys === true) {
     parsed = llmLoadSchematics.parse(config);
   } else {
     parsed = llmLoadSchematics.parsePartial(config);

--- a/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmLoadModelConfig.ts
@@ -7,10 +7,18 @@ import {
 import { collapseKVStackRaw } from "../KVConfig.js";
 import { llmLoadSchematics } from "../schema.js";
 
-export function kvConfigToLLMLoadModelConfig(config: KVConfig): LLMLoadModelConfig {
+export function kvConfigToLLMLoadModelConfig(
+  config: KVConfig,
+  notPartial?: boolean,
+): LLMLoadModelConfig {
   const result: LLMLoadModelConfig = {};
-  const parsed = llmLoadSchematics.parse(config);
 
+  let parsed;
+  if (notPartial === true) {
+    parsed = llmLoadSchematics.parse(config);
+  } else {
+    parsed = llmLoadSchematics.parsePartial(config);
+  }
   const gpuSplitConfig = parsed.get("gpuSplitConfig");
   if (gpuSplitConfig !== undefined) {
     const gpuSetting = convertGPUSplitConfigToGPUSetting(gpuSplitConfig);

--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -2,10 +2,15 @@ import { type KVConfig, type LLMPredictionConfig } from "@lmstudio/lms-shared-ty
 import { collapseKVStackRaw } from "../KVConfig.js";
 import { llmPredictionConfigSchematics } from "../schema.js";
 import { maybeFalseNumberToCheckboxNumeric } from "./utils.js";
-export function kvConfigToLLMPredictionConfig(config: KVConfig) {
-  const result: LLMPredictionConfig = {};
-  const parsed = llmPredictionConfigSchematics.parse(config);
 
+export function kvConfigToLLMPredictionConfig(config: KVConfig, notPartial?: boolean) {
+  const result: LLMPredictionConfig = {};
+  let parsed;
+  if (notPartial === true) {
+    parsed = llmPredictionConfigSchematics.parse(config);
+  } else {
+    parsed = llmPredictionConfigSchematics.parsePartial(config);
+  }
   const maxPredictedTokens = parsed.get("maxPredictedTokens");
   if (maxPredictedTokens !== undefined) {
     result.maxTokens = maxPredictedTokens.checked ? maxPredictedTokens.value : false;

--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -3,7 +3,14 @@ import { collapseKVStackRaw } from "../KVConfig.js";
 import { llmPredictionConfigSchematics } from "../schema.js";
 import { maybeFalseNumberToCheckboxNumeric } from "./utils.js";
 
-export function kvConfigToLLMPredictionConfig(config: KVConfig, notPartial?: boolean) {
+interface KvConfigToLLMPredictionConfigOpts {
+  notPartial?: boolean;
+}
+
+export function kvConfigToLLMPredictionConfig(
+  config: KVConfig,
+  { notPartial }: KvConfigToLLMPredictionConfigOpts = {},
+) {
   const result: LLMPredictionConfig = {};
   let parsed;
   if (notPartial === true) {

--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -4,16 +4,19 @@ import { llmPredictionConfigSchematics } from "../schema.js";
 import { maybeFalseNumberToCheckboxNumeric } from "./utils.js";
 
 interface KvConfigToLLMPredictionConfigOpts {
-  notPartial?: boolean;
+  /**
+   * Fills the missing keys passed in with default values
+   */
+  useDefaultsForMissingKeys?: boolean;
 }
 
 export function kvConfigToLLMPredictionConfig(
   config: KVConfig,
-  { notPartial }: KvConfigToLLMPredictionConfigOpts = {},
+  { useDefaultsForMissingKeys }: KvConfigToLLMPredictionConfigOpts = {},
 ) {
   const result: LLMPredictionConfig = {};
   let parsed;
-  if (notPartial === true) {
+  if (useDefaultsForMissingKeys === true) {
     parsed = llmPredictionConfigSchematics.parse(config);
   } else {
     parsed = llmPredictionConfigSchematics.parsePartial(config);

--- a/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
+++ b/packages/lms-kv-config/src/conversion/llmPredictionConfig.ts
@@ -1,115 +1,112 @@
 import { type KVConfig, type LLMPredictionConfig } from "@lmstudio/lms-shared-types";
 import { collapseKVStackRaw } from "../KVConfig.js";
-import { globalConfigSchematics, llmPredictionConfigSchematics } from "../schema.js";
+import { llmPredictionConfigSchematics } from "../schema.js";
 import { maybeFalseNumberToCheckboxNumeric } from "./utils.js";
-
 export function kvConfigToLLMPredictionConfig(config: KVConfig) {
   const result: LLMPredictionConfig = {};
-  const parsed = globalConfigSchematics.parsePartial(config);
+  const parsed = llmPredictionConfigSchematics.parse(config);
 
-  const maxPredictedTokens = parsed.get("llm.prediction.maxPredictedTokens");
+  const maxPredictedTokens = parsed.get("maxPredictedTokens");
   if (maxPredictedTokens !== undefined) {
     result.maxTokens = maxPredictedTokens.checked ? maxPredictedTokens.value : false;
   }
-  const temperature = parsed.get("llm.prediction.temperature");
+  const temperature = parsed.get("temperature");
   if (temperature !== undefined) {
     result.temperature = temperature;
   }
 
-  const stopStrings = parsed.get("llm.prediction.stopStrings");
+  const stopStrings = parsed.get("stopStrings");
   if (stopStrings !== undefined) {
     result.stopStrings = stopStrings;
   }
 
-  const toolCallStopStrings = parsed.get("llm.prediction.toolCallStopStrings");
+  const toolCallStopStrings = parsed.get("toolCallStopStrings");
   if (toolCallStopStrings !== undefined) {
     result.toolCallStopStrings = toolCallStopStrings;
   }
 
-  const contextOverflowPolicy = parsed.get("llm.prediction.contextOverflowPolicy");
+  const contextOverflowPolicy = parsed.get("contextOverflowPolicy");
   if (contextOverflowPolicy !== undefined) {
     result.contextOverflowPolicy = contextOverflowPolicy;
   }
 
-  const structured = parsed.get("llm.prediction.structured");
+  const structured = parsed.get("structured");
   if (structured !== undefined) {
     result.structured = structured;
   }
 
-  const tools = parsed.get("llm.prediction.tools");
+  const tools = parsed.get("tools");
   if (tools !== undefined) {
     result.rawTools = tools;
   }
 
-  const toolChoice = parsed.get("llm.prediction.toolChoice");
+  const toolChoice = parsed.get("toolChoice");
   if (toolChoice !== undefined) {
     result.toolChoice = toolChoice;
   }
 
-  const toolNaming = parsed.get("llm.prediction.toolNaming");
+  const toolNaming = parsed.get("toolNaming");
   if (toolNaming !== undefined) {
     result.toolNaming = toolNaming;
   }
 
-  const topKSampling = parsed.get("llm.prediction.topKSampling");
+  const topKSampling = parsed.get("topKSampling");
   if (topKSampling !== undefined) {
     result.topKSampling = topKSampling;
   }
 
-  const repeatPenalty = parsed.get("llm.prediction.repeatPenalty");
+  const repeatPenalty = parsed.get("repeatPenalty");
   if (repeatPenalty !== undefined) {
     result.repeatPenalty = repeatPenalty.checked ? repeatPenalty.value : false;
   }
 
-  const minPSampling = parsed.get("llm.prediction.minPSampling");
+  const minPSampling = parsed.get("minPSampling");
   if (minPSampling !== undefined) {
     result.minPSampling = minPSampling.checked ? minPSampling.value : false;
   }
 
-  const topPSampling = parsed.get("llm.prediction.topPSampling");
+  const topPSampling = parsed.get("topPSampling");
   if (topPSampling !== undefined) {
     result.topPSampling = topPSampling.checked ? topPSampling.value : false;
   }
 
-  const xtcProbability = parsed.get("llm.prediction.llama.xtcProbability");
+  const xtcProbability = parsed.get("llama.xtcProbability");
   if (xtcProbability !== undefined) {
     result.xtcProbability = xtcProbability.checked ? xtcProbability.value : false;
   }
 
-  const xtcThreshold = parsed.get("llm.prediction.llama.xtcThreshold");
+  const xtcThreshold = parsed.get("llama.xtcThreshold");
   if (xtcThreshold !== undefined) {
     result.xtcThreshold = xtcThreshold.checked ? xtcThreshold.value : false;
   }
 
-  const logProbs = parsed.get("llm.prediction.logProbs");
+  const logProbs = parsed.get("logProbs");
   if (logProbs !== undefined) {
     result.logProbs = logProbs.checked ? logProbs.value : false;
   }
 
-  const cpuThreads = parsed.get("llm.prediction.llama.cpuThreads");
+  const cpuThreads = parsed.get("llama.cpuThreads");
   if (cpuThreads !== undefined) {
     result.cpuThreads = cpuThreads;
   }
 
-  const promptTemplate = parsed.get("llm.prediction.promptTemplate");
+  const promptTemplate = parsed.get("promptTemplate");
   if (promptTemplate !== undefined) {
     result.promptTemplate = promptTemplate;
   }
 
-  const speculativeDecodingDraftModel = parsed.get("llm.prediction.speculativeDecoding.draftModel");
+  const speculativeDecodingDraftModel = parsed.get("speculativeDecoding.draftModel");
   if (speculativeDecodingDraftModel !== undefined) {
     result.draftModel = speculativeDecodingDraftModel;
   }
 
-  const speculativeDecodingDraftTokensExact = parsed.get(
-    "llm.prediction.speculativeDecoding.numDraftTokensExact",
-  );
+  const speculativeDecodingDraftTokensExact = parsed.get("speculativeDecoding.numDraftTokensExact");
   if (speculativeDecodingDraftTokensExact !== undefined) {
     result.speculativeDecodingNumDraftTokensExact = speculativeDecodingDraftTokensExact;
   }
 
   const speculativeDecodingMinContinueDraftingProbability = parsed.get(
-    "llm.prediction.speculativeDecoding.minContinueDraftingProbability",
+    "speculativeDecoding.minContinueDraftingProbability",
   );
   if (speculativeDecodingMinContinueDraftingProbability !== undefined) {
     result.speculativeDecodingMinContinueDraftingProbability =
@@ -117,14 +114,14 @@ export function kvConfigToLLMPredictionConfig(config: KVConfig) {
   }
 
   const speculativeDecodingMinDraftLengthToConsider = parsed.get(
-    "llm.prediction.speculativeDecoding.minDraftLengthToConsider",
+    "speculativeDecoding.minDraftLengthToConsider",
   );
   if (speculativeDecodingMinDraftLengthToConsider !== undefined) {
     result.speculativeDecodingMinDraftLengthToConsider =
       speculativeDecodingMinDraftLengthToConsider;
   }
 
-  const reasoningParsing = parsed.get("llm.prediction.reasoning.parsing");
+  const reasoningParsing = parsed.get("reasoning.parsing");
   if (reasoningParsing !== undefined) {
     result.reasoningParsing = reasoningParsing;
   }

--- a/packages/lms-kv-config/src/index.ts
+++ b/packages/lms-kv-config/src/index.ts
@@ -3,6 +3,10 @@ export {
   llmPredictionConfigToKVConfig,
 } from "./conversion/llmPredictionConfig.js";
 export {
+  kvConfigToLLMLoadModelConfig,
+  llmLoadModelConfigToKVConfig,
+} from "./conversion/llmLoadModelConfig.js";
+export {
   addKVConfigToBaseOfStack,
   addKVConfigToStack,
   collapseKVStack,

--- a/packages/lms-kv-config/src/index.ts
+++ b/packages/lms-kv-config/src/index.ts
@@ -7,6 +7,10 @@ export {
   llmLoadModelConfigToKVConfig,
 } from "./conversion/llmLoadModelConfig.js";
 export {
+  kvConfigToEmbeddingLoadModelConfig,
+  embeddingLoadModelConfigToKVConfig,
+} from "./conversion/embeddingLoadModelConfig.js";
+export {
   addKVConfigToBaseOfStack,
   addKVConfigToStack,
   collapseKVStack,

--- a/packages/lms-kv-config/src/schema.ts
+++ b/packages/lms-kv-config/src/schema.ts
@@ -429,7 +429,8 @@ export const llmMistralrsPredictionConfigSchematics = llmSharedPredictionConfigS
 
 export const llmLoadSchematics = globalConfigSchematics
   .scoped("llm.load")
-  .union(globalConfigSchematics.sliced("envVars"));
+  .union(globalConfigSchematics.sliced("envVars"))
+  .union(globalConfigSchematics.scoped("load"));
 
 export const llmSharedLoadConfigSchematics = llmLoadSchematics.sliced(
   "contextLength",

--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -61,3 +61,16 @@ export function convertGPUSettingToGPUSplitConfig(gpuSetting?: GPUSetting): GPUS
     customRatio: [],
   };
 }
+
+export function convertGPUSplitConfigToGPUSetting(splitConfig: GPUSplitConfig): GPUSetting {
+  return {
+    splitStrategy:
+      splitConfig.strategy === "priorityOrder"
+        ? "favorMainGpu"
+        : splitConfig.strategy === "evenly"
+          ? "evenly"
+          : undefined,
+    disabledGpus: splitConfig.disabledGpus,
+    mainGpu: splitConfig.priority.length > 0 ? splitConfig.priority[0] : undefined,
+  };
+}

--- a/packages/lms-shared-types/src/index.ts
+++ b/packages/lms-shared-types/src/index.ts
@@ -100,6 +100,7 @@ export {
 export { FileType, fileTypeSchema } from "./files/FileType.js";
 export {
   convertGPUSettingToGPUSplitConfig,
+  convertGPUSplitConfigToGPUSetting,
   defaultGPUSplitConfig,
   GPUSplitConfig,
   gpuSplitConfigSchema,


### PR DESCRIPTION
## Overview

Adds the ability to get configurations programmatically via the SDK. 


For LLMs:

```typescript
const predictionConfig = await llm.getBasePredictionConfig();
const loadConfig = await llm.getLoadConfig();
```

and for embedding models:

```typescript
const loadConfig = await embedding.getLoadConfig();
```

