### PR TITLE
Disposing planner should not cancel download

### DIFF
--- a/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
+++ b/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
@@ -207,7 +207,7 @@ export class ArtifactDownloadPlanner {
     this.channel.send({ type: "commit" });
     this.isPlanCommited = true;
     // Here we send cancel because the signal was aborted from the outside. This means the user
-    // doesn't  want to continue the download
+    // doesn't want to continue the download
     if (signal.aborted) {
       this.channel.send({ type: "cancelDownload" });
     } else {

--- a/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
+++ b/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
@@ -47,7 +47,7 @@ export class ArtifactDownloadPlanner {
   private readyDeferredPromise = makePromise<void>();
   private readonly logger: SimpleLogger;
   private isReadyBoolean = false;
-  private plannedCommited: boolean = false;
+  private isPlanCommited: boolean = false;
   private planValue: ArtifactDownloadPlan;
   private currentDownload: ArtifactDownloadPlannerCurrentDownload | null = null;
   /**
@@ -150,8 +150,7 @@ export class ArtifactDownloadPlanner {
   public [Symbol.dispose]() {
     // If the channel is still open, we need to cancel the plan. This ensures we don't cancel the
     // download even if the download planner goes out of scope.
-
-    if (this.plannedCommited === false) {
+    if (this.isPlanCommited === false) {
       this.channel.send({ type: "cancelPlan" });
     }
     this.onDisposed();
@@ -206,9 +205,9 @@ export class ArtifactDownloadPlanner {
       },
     };
     this.channel.send({ type: "commit" });
-    this.plannedCommited = true;
-    // Here we send cancel which would cancel the download because the signal was aborted from
-    // outside That would mean the user doesn't want to continue the download
+    this.isPlanCommited = true;
+    // Here we send cancel because the signal was aborted from the outside. This means the user
+    // doesn't  want to continue the download
     if (signal.aborted) {
       this.channel.send({ type: "cancelDownload" });
     } else {

--- a/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
+++ b/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
@@ -60,7 +60,6 @@ export class ArtifactDownloadPlanner {
    * a listener there
    */
   private errorReceivedBeforeDownloadStart: Error | null = null;
-
   /**
    * @internal Do not construct this class yourself.
    */
@@ -143,9 +142,10 @@ export class ArtifactDownloadPlanner {
   }
 
   public [Symbol.dispose]() {
-    // If the channel is still open, we need to cancel the plan.
+    // If the channel is still open, we need to cancel the plan. This ensures we don't cancel the
+    // download even if the download planner goes out of scope.
     if (this.isChannelClosed === false) {
-      this.channel.send({ type: "cancel" });
+      this.channel.send({ type: "cancelPlan" });
     }
     this.onDisposed();
   }
@@ -199,6 +199,8 @@ export class ArtifactDownloadPlanner {
       },
     };
     this.channel.send({ type: "commit" });
+    // Here we send cancel which would cancel the download because the signal was aborted from
+    // outside That would mean the user doesn't want to continue the download
     if (signal.aborted) {
       this.channel.send({ type: "cancel" });
     } else {

--- a/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
+++ b/packages/lms-client/src/repository/ArtifactDownloadPlanner.ts
@@ -6,7 +6,6 @@ import {
   type Validator,
 } from "@lmstudio/lms-common";
 import { type InferClientChannelType } from "@lmstudio/lms-communication";
-import { ConnectionStatus } from "@lmstudio/lms-communication/dist/types/Channel";
 import { type RepositoryBackendInterface } from "@lmstudio/lms-external-backend-interfaces";
 import { type ArtifactDownloadPlan, type DownloadProgressUpdate } from "@lmstudio/lms-shared-types";
 import { z } from "zod";

--- a/packages/lms-client/src/repository/ModelSearchResultDownloadOption.ts
+++ b/packages/lms-client/src/repository/ModelSearchResultDownloadOption.ts
@@ -7,6 +7,7 @@ import {
 } from "@lmstudio/lms-common";
 import { type RepositoryPort } from "@lmstudio/lms-external-backend-interfaces";
 import {
+  type ModelCompatibilityType,
   type DownloadProgressUpdate,
   type ModelSearchResultDownloadOptionData,
   type ModelSearchResultDownloadOptionFitEstimation,
@@ -32,6 +33,7 @@ export class ModelSearchResultDownloadOption {
   public readonly sizeBytes: number;
   public readonly fitEstimation?: ModelSearchResultDownloadOptionFitEstimation;
   public readonly indexedModelIdentifier: string;
+  public readonly compatibilityType: ModelCompatibilityType;
   /** @internal */
   public constructor(
     /** @internal */
@@ -46,6 +48,7 @@ export class ModelSearchResultDownloadOption {
     this.sizeBytes = data.sizeBytes;
     this.fitEstimation = this.data.fitEstimation;
     this.indexedModelIdentifier = this.data.indexedModelIdentifier;
+    this.compatibilityType = this.data.compatibilityType;
   }
   public isRecommended() {
     return this.data.recommended ?? false;

--- a/packages/lms-client/src/repository/RepositoryNamespace.ts
+++ b/packages/lms-client/src/repository/RepositoryNamespace.ts
@@ -131,11 +131,13 @@ export interface CreateArtifactDownloadPlannerOpts {
   owner: string;
   name: string;
   onPlanUpdated?: (plan: ArtifactDownloadPlan) => void;
+  signal?: AbortSignal;
 }
 export const createArtifactDownloadPlannerOptsSchema = z.object({
   owner: z.string(),
   name: z.string(),
   onPlanUpdated: z.function().optional(),
+  signal: z.instanceof(AbortSignal).optional(),
 }) as ZodSchema<CreateArtifactDownloadPlannerOpts>;
 
 /**
@@ -396,7 +398,7 @@ export class RepositoryNamespace {
   public createArtifactDownloadPlanner(
     opts: CreateArtifactDownloadPlannerOpts,
   ): ArtifactDownloadPlanner {
-    const { owner, name, onPlanUpdated } = this.validator.validateMethodParamOrThrow(
+    const { owner, name, onPlanUpdated, signal } = this.validator.validateMethodParamOrThrow(
       "repository",
       "createArtifactDownloadPlanner",
       "opts",
@@ -419,6 +421,7 @@ export class RepositoryNamespace {
       () => {
         this.downloadPlanFinalizationRegistry.unregister(planner);
       },
+      signal,
     );
     this.downloadPlanFinalizationRegistry.register(planner, { owner, name }, planner);
     return planner;

--- a/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
@@ -161,11 +161,10 @@ export function createRepositoryBackendInterface() {
         }),
         toServerPacket: z.discriminatedUnion("type", [
           /**
-           * If called before committing the plan, the plan is aborted. If called after committing
-           * the plan, the download is canceled.
+           * Cancels the download.
            */
           z.object({
-            type: z.literal("cancel"),
+            type: z.literal("cancelDownload"),
           }),
           /**
            * Can only be called after plan ready. Once called, starts the plan.
@@ -174,8 +173,7 @@ export function createRepositoryBackendInterface() {
             type: z.literal("commit"),
           }),
           /**
-           * If called before committing the plan, the plan is aborted. If called after committing
-           * the plan, the download will still continue.
+           * Aborts the plan.
            */
           z.object({
             type: z.literal("cancelPlan"),

--- a/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
+++ b/packages/lms-external-backend-interfaces/src/repositoryBackendInterface.ts
@@ -173,6 +173,13 @@ export function createRepositoryBackendInterface() {
           z.object({
             type: z.literal("commit"),
           }),
+          /**
+           * If called before committing the plan, the plan is aborted. If called after committing
+           * the plan, the download will still continue.
+           */
+          z.object({
+            type: z.literal("cancelPlan"),
+          }),
         ]),
         toClientPacket: z.discriminatedUnion("type", [
           z.object({

--- a/packages/lms-shared-types/src/repository/ModelSearch.ts
+++ b/packages/lms-shared-types/src/repository/ModelSearch.ts
@@ -27,6 +27,7 @@ export interface ModelSearchResultDownloadOptionData {
   recommended?: boolean;
   downloadIdentifier: string;
   indexedModelIdentifier: string;
+  compatibilityType: ModelCompatibilityType;
 }
 export const modelSearchResultDownloadOptionDataSchema = z.object({
   quantization: z.string().optional(),
@@ -36,6 +37,7 @@ export const modelSearchResultDownloadOptionDataSchema = z.object({
   recommended: z.boolean().optional(),
   downloadIdentifier: z.string(),
   indexedModelIdentifier: z.string(),
+  compatibilityType: modelCompatibilityTypeSchema,
 }) as ZodSchema<ModelSearchResultDownloadOptionData>;
 
 export type ModelSearchResultIdentifier =


### PR DESCRIPTION
## Overview

This PR plans to fix the artifact download planner clean up, splitting the abort events into two types - `cancelPlan` and `cancelDownload` which will resolve a lot of communication warnings. 


This PR also brings in `compatibilityType` for Model search option data 