### PR TITLE
Don't override GPU settings if gpu settings are not overidden

### DIFF
--- a/packages/lms-shared-types/src/GPUSplitStrategy.ts
+++ b/packages/lms-shared-types/src/GPUSplitStrategy.ts
@@ -50,7 +50,12 @@ export const gpuSplitConfigSchema = z.object({
   customRatio: z.array(z.number().min(0)),
 });
 
-export function convertGPUSettingToGPUSplitConfig(gpuSetting?: GPUSetting): GPUSplitConfig {
+export function convertGPUSettingToGPUSplitConfig(
+  gpuSetting?: GPUSetting,
+): GPUSplitConfig | undefined {
+  if (gpuSetting === undefined) {
+    return undefined;
+  }
   return {
     strategy:
       gpuSetting?.splitStrategy == "favorMainGpu"


### PR DESCRIPTION
Previously, if SDK did not specify gpu settings, we still added an override with default values. Instead, if gpuSettings is undefined, don't override.

Fixes https://github.com/lmstudio-ai/lms/issues/338