### PR TITLE
fix(plugin-runner): emit ESM bundles for Node plugins

### DIFF
--- a/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
@@ -1,0 +1,11 @@
+import { createEsBuildArgs } from "./esbuildArgs.js";
+
+test("Node plugin builds use ESM output", () => {
+  const args = createEsBuildArgs({
+    entryPath: "/tmp/plugin/.lmstudio/entry.ts",
+    outPath: "/tmp/plugin/.lmstudio/production.js",
+    production: true,
+  });
+
+  expect(args).toContain("--format=esm");
+});

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
@@ -16,7 +16,7 @@ test("Node plugin builds use ESM output", () => {
 
   expect(args).toContain("--format=esm");
   expect(args).toContain(
-    '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; const require = __lmsCreateRequire(import.meta.url); const __filename = __lmsFileURLToPath(import.meta.url); const __dirname = __lmsDirname(__filename);',
+    '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; if (!("require" in globalThis)) Object.defineProperty(globalThis, "require", { value: __lmsCreateRequire(import.meta.url), configurable: true }); if (!("__filename" in globalThis)) Object.defineProperty(globalThis, "__filename", { value: __lmsFileURLToPath(import.meta.url), configurable: true }); if (!("__dirname" in globalThis)) Object.defineProperty(globalThis, "__dirname", { value: __lmsDirname(globalThis.__filename), configurable: true });',
   );
 });
 
@@ -45,6 +45,32 @@ test("ESM build banner restores CommonJS file globals", async () => {
     expect(globals.requireType).toBe("function");
     expect(basename(globals.filename)).toBe("bundle.mjs");
     expect(globals.dirname).toBe(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("ESM build banner does not collide with plugin-provided file globals", async () => {
+  const args = createEsBuildArgs({
+    entryPath: "/tmp/plugin/.lmstudio/entry.ts",
+    outPath: "/tmp/plugin/.lmstudio/production.js",
+  });
+  const banner = args.find(arg => arg.startsWith("--banner:js="))!.slice("--banner:js=".length);
+  const directory = await mkdtemp(join(tmpdir(), "lms-esm-banner-collision-"));
+  const bundlePath = join(directory, "bundle.mjs");
+
+  try {
+    await writeFile(
+      bundlePath,
+      `${banner}\nconst require = "plugin require"; const __filename = "plugin filename"; const __dirname = "plugin dirname"; console.log(JSON.stringify({ require, filename: __filename, dirname: __dirname }));`,
+      "utf-8",
+    );
+    const { stdout } = await execFileAsync(process.execPath, [bundlePath]);
+    expect(JSON.parse(stdout)).toEqual({
+      require: "plugin require",
+      filename: "plugin filename",
+      dirname: "plugin dirname",
+    });
   } finally {
     await rm(directory, { recursive: true, force: true });
   }

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
@@ -1,4 +1,11 @@
+import { execFile } from "child_process";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { basename, join } from "path";
+import { promisify } from "util";
 import { createEsBuildArgs } from "./esbuildArgs.js";
+
+const execFileAsync = promisify(execFile);
 
 test("Node plugin builds use ESM output", () => {
   const args = createEsBuildArgs({
@@ -9,6 +16,36 @@ test("Node plugin builds use ESM output", () => {
 
   expect(args).toContain("--format=esm");
   expect(args).toContain(
-    '--banner:js=import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+    '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; const require = __lmsCreateRequire(import.meta.url); const __filename = __lmsFileURLToPath(import.meta.url); const __dirname = __lmsDirname(__filename);',
   );
+});
+
+test("ESM build banner restores CommonJS file globals", async () => {
+  const args = createEsBuildArgs({
+    entryPath: "/tmp/plugin/.lmstudio/entry.ts",
+    outPath: "/tmp/plugin/.lmstudio/production.js",
+  });
+  const banner = args.find(arg => arg.startsWith("--banner:js="))!.slice("--banner:js=".length);
+  const directory = await mkdtemp(join(tmpdir(), "lms-esm-banner-"));
+  const bundlePath = join(directory, "bundle.mjs");
+
+  try {
+    await writeFile(
+      bundlePath,
+      `${banner}\nconsole.log(JSON.stringify({ requireType: typeof require, filename: __filename, dirname: __dirname }));`,
+      "utf-8",
+    );
+    const { stdout } = await execFileAsync(process.execPath, [bundlePath]);
+    const globals = JSON.parse(stdout) as {
+      requireType: string;
+      filename: string;
+      dirname: string;
+    };
+
+    expect(globals.requireType).toBe("function");
+    expect(basename(globals.filename)).toBe("bundle.mjs");
+    expect(globals.dirname).toBe(directory);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.test.ts
@@ -8,4 +8,7 @@ test("Node plugin builds use ESM output", () => {
   });
 
   expect(args).toContain("--format=esm");
+  expect(args).toContain(
+    '--banner:js=import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+  );
 });

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.ts
@@ -11,8 +11,8 @@ const alwaysArgs = [
   "--tree-shaking=true",
   "--bundle",
   "--format=esm",
-  // Keep CommonJS plugin sources that use require() working in the ESM bundle.
-  '--banner:js=import { createRequire } from "module"; const require = createRequire(import.meta.url);',
+  // Keep CommonJS plugin sources that use Node's module and file globals working in the ESM bundle.
+  '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; const require = __lmsCreateRequire(import.meta.url); const __filename = __lmsFileURLToPath(import.meta.url); const __dirname = __lmsDirname(__filename);',
   // Don't bundle node_modules as they are not necessarily designed to be bundled.
   "--packages=external",
 ];

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.ts
@@ -10,6 +10,7 @@ const alwaysArgs = [
   "--sourcemap=inline",
   "--tree-shaking=true",
   "--bundle",
+  "--format=esm",
   // Don't bundle node_modules as they are not necessarily designed to be bundled.
   "--packages=external",
 ];

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.ts
@@ -12,7 +12,7 @@ const alwaysArgs = [
   "--bundle",
   "--format=esm",
   // Keep CommonJS plugin sources that use Node's module and file globals working in the ESM bundle.
-  '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; const require = __lmsCreateRequire(import.meta.url); const __filename = __lmsFileURLToPath(import.meta.url); const __dirname = __lmsDirname(__filename);',
+  '--banner:js=import { createRequire as __lmsCreateRequire } from "module"; import { fileURLToPath as __lmsFileURLToPath } from "url"; import { dirname as __lmsDirname } from "path"; if (!("require" in globalThis)) Object.defineProperty(globalThis, "require", { value: __lmsCreateRequire(import.meta.url), configurable: true }); if (!("__filename" in globalThis)) Object.defineProperty(globalThis, "__filename", { value: __lmsFileURLToPath(import.meta.url), configurable: true }); if (!("__dirname" in globalThis)) Object.defineProperty(globalThis, "__dirname", { value: __lmsDirname(globalThis.__filename), configurable: true });',
   // Don't bundle node_modules as they are not necessarily designed to be bundled.
   "--packages=external",
 ];

--- a/packages/lms-es-plugin-runner/src/esbuildArgs.ts
+++ b/packages/lms-es-plugin-runner/src/esbuildArgs.ts
@@ -11,6 +11,8 @@ const alwaysArgs = [
   "--tree-shaking=true",
   "--bundle",
   "--format=esm",
+  // Keep CommonJS plugin sources that use require() working in the ESM bundle.
+  '--banner:js=import { createRequire } from "module"; const require = createRequire(import.meta.url);',
   // Don't bundle node_modules as they are not necessarily designed to be bundled.
   "--packages=external",
 ];

--- a/packages/lms-es-plugin-runner/src/generateEntryFile.test.ts
+++ b/packages/lms-es-plugin-runner/src/generateEntryFile.test.ts
@@ -1,0 +1,14 @@
+import { mkdtemp, readFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { generateEntryFileAt } from "./generateEntryFile.js";
+
+test("generating a plugin entry file marks the cache directory as ESM", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "lms-plugin-runner-"));
+
+  await generateEntryFileAt(join(directory, "entry.ts"), {});
+
+  await expect(readFile(join(directory, "package.json"), "utf-8")).resolves.toBe(
+    '{"type":"module"}\n',
+  );
+});

--- a/packages/lms-es-plugin-runner/src/generateEntryFile.ts
+++ b/packages/lms-es-plugin-runner/src/generateEntryFile.ts
@@ -1,5 +1,5 @@
 import { mkdir, writeFile } from "fs/promises";
-import { dirname } from "path";
+import { dirname, join } from "path";
 
 const template = `\
 import { LMStudioClient, type PluginContext } from "@lmstudio/sdk";
@@ -106,4 +106,9 @@ export async function generateEntryFileAt(path: string, _opts: GenerateEntryFile
   const directoryPath = dirname(path);
   await mkdir(directoryPath, { recursive: true });
   await writeFile(path, template, "utf-8");
+  await writeFile(
+    join(directoryPath, "package.json"),
+    JSON.stringify({ type: "module" }) + "\n",
+    "utf-8",
+  );
 }


### PR DESCRIPTION
## Summary

- Emit Node plugin bundles as ESM.
- Add regression coverage for the shared esbuild arguments.

## Problem

Node plugins with `"type": "module"` failed at runtime because esbuild's default Node format generated CommonJS `require` calls for `.lmstudio/dev.js` and `.lmstudio/production.js`.

## Call graph

`packages/lms-es-plugin-runner/src/esbuildArgs.ts:16` (`createEsBuildArgs`)
→ `NodePluginInstaller` / `NodePluginRunnerWatcher`
→ esbuild output `.lmstudio/dev.js` or `.lmstudio/production.js`

The shared argument builder now passes `--format=esm`, so the generated files load correctly in ESM plugin packages.

## Tests

- `npm test -- --runInBand --coverage=false --silent`
- `npx turbo run build --filter=@lmstudio/lms-es-plugin-runner...`
- `npx tsc --build packages/lms-es-plugin-runner/tsconfig.json`
- `npx prettier --check packages/lms-es-plugin-runner/src/esbuildArgs.ts packages/lms-es-plugin-runner/src/esbuildArgs.test.ts`
- `npx eslint packages/lms-es-plugin-runner/src/esbuildArgs.ts packages/lms-es-plugin-runner/src/esbuildArgs.test.ts`
- `git diff --check`

Fixes #586
## Review update validation

- `npm test -- --runInBand --coverage=false --silent packages/lms-es-plugin-runner/src/esbuildArgs.test.ts` — 2 passed
- `npx prettier --check packages/lms-es-plugin-runner/src/esbuildArgs.ts packages/lms-es-plugin-runner/src/esbuildArgs.test.ts` — passed
- `npx eslint packages/lms-es-plugin-runner/src/esbuildArgs.ts packages/lms-es-plugin-runner/src/esbuildArgs.test.ts` — passed
- `git diff --check` — passed
- `npx tsc --build packages/lms-es-plugin-runner/tsconfig.json` — not completed in this clean checkout because `npm ci`'s repository postinstall could not find the `@lmstudio/lms-cli` workspace, leaving `@lmstudio/lms-common` and `@lmstudio/lms-common-server` unlinked; the focused test compiles and executes the banner under Node.