### PR TITLE
Install fish CLI PATH setup in conf.d

### DIFF
--- a/packages/lms-lmstudio/src/installCli/darwinOrLinux.test.ts
+++ b/packages/lms-lmstudio/src/installCli/darwinOrLinux.test.ts
@@ -1,0 +1,98 @@
+import inquirer from "inquirer";
+import { execSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import { installCliDarwinOrLinux } from "./darwinOrLinux.js";
+
+jest.mock("node:child_process", () => ({ execSync: jest.fn() }));
+
+let fixtureDir: string;
+let targetPath: string;
+let configPath: string;
+let snippetPath: string;
+
+beforeEach(async () => {
+  fixtureDir = await mkdtemp(join(os.tmpdir(), "lms-installer-test-"));
+  targetPath = join(fixtureDir, ".lmstudio", "bin");
+  configPath = join(fixtureDir, ".config", "fish", "config.fish");
+  snippetPath = join(fixtureDir, ".config", "fish", "conf.d", "lms.fish");
+  jest.spyOn(os, "homedir").mockReturnValue(fixtureDir);
+  jest.replaceProperty(process, "env", {
+    ...process.env,
+    SHELL: "/usr/bin/fish",
+    XDG_CONFIG_HOME: "",
+  });
+  jest.spyOn(console, "info").mockImplementation(() => {});
+  jest.mocked(execSync).mockClear();
+});
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+test("migrates fish even when config.fish already contains the absolute target", async () => {
+  await mkdir(dirname(configPath), { recursive: true });
+  await writeFile(
+    configPath,
+    `# Added by LM Studio CLI tool (lms)\nset -gx PATH $PATH ${targetPath}\n`,
+  );
+  await installCliDarwinOrLinux(targetPath, { skipConfirmation: true });
+  expect(await readFile(configPath, "utf8")).toBe("");
+  expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path --append --path");
+  expect(execSync).not.toHaveBeenCalled();
+});
+
+test("reports the snippet destination on installation and subsequent already-installed runs", async () => {
+  process.env.XDG_CONFIG_HOME = join(fixtureDir, "custom config");
+  const destination = join(process.env.XDG_CONFIG_HOME, "fish", "conf.d", "lms.fish");
+  await installCliDarwinOrLinux(targetPath, { skipConfirmation: true });
+  expect(console.info).toHaveBeenCalledWith(expect.stringContaining(destination));
+  jest.mocked(console.info).mockClear();
+  await installCliDarwinOrLinux(targetPath, { skipConfirmation: true });
+  expect(console.info).toHaveBeenCalledWith(expect.stringContaining("Already Installed"));
+  expect(console.info).toHaveBeenCalledWith(expect.stringContaining(`(${destination})`));
+  expect(execSync).not.toHaveBeenCalled();
+});
+
+test.each([false, true])(
+  "honors confirmation before any fish writes (continue: %s)",
+  async cont => {
+    await mkdir(dirname(configPath), { recursive: true });
+    const legacy = `# Added by LM Studio CLI tool (lms)\nset -gx PATH $PATH ${targetPath}\n`;
+    await writeFile(configPath, legacy);
+    const prompt = jest.fn().mockResolvedValue({ cont });
+    jest
+      .spyOn(inquirer, "createPromptModule")
+      .mockReturnValue(prompt as unknown as ReturnType<typeof inquirer.createPromptModule>);
+    await installCliDarwinOrLinux(targetPath, {});
+    expect(prompt).toHaveBeenCalledTimes(1);
+    expect(console.info).toHaveBeenCalledWith(expect.stringContaining(snippetPath));
+    if (cont) {
+      expect(await readFile(configPath, "utf8")).toBe("");
+      expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path");
+    } else {
+      expect(await readFile(configPath, "utf8")).toBe(legacy);
+      await expect(stat(snippetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    }
+  },
+);
+
+test("leaves the existing bash installation command unchanged", async () => {
+  process.env.SHELL = "/bin/bash";
+  await writeFile(join(fixtureDir, ".bashrc"), "# personal config\n");
+  await installCliDarwinOrLinux(targetPath, { skipConfirmation: true });
+  expect(execSync).toHaveBeenCalledWith(
+    `echo '' >> ~/.bashrc && echo '# Added by LM Studio CLI tool (lms)' >> ~/.bashrc && echo 'export PATH="$PATH:${targetPath}"' >> ~/.bashrc`,
+  );
+  await expect(stat(snippetPath)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("installs fish alongside an existing zsh configuration", async () => {
+  await writeFile(join(fixtureDir, ".zshrc"), "# personal config\n");
+  await installCliDarwinOrLinux(targetPath, { skipConfirmation: true });
+  expect(execSync).toHaveBeenCalledTimes(1);
+  expect(execSync).toHaveBeenCalledWith(expect.stringContaining(">> ~/.zshrc"));
+  expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path");
+});

--- a/packages/lms-lmstudio/src/installCli/darwinOrLinux.ts
+++ b/packages/lms-lmstudio/src/installCli/darwinOrLinux.ts
@@ -5,8 +5,9 @@ import inquirer from "inquirer";
 import { execSync } from "node:child_process";
 import { access, readFile } from "node:fs/promises";
 import os from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 import { type InstallCliOpts } from ".";
+import { applyFishInstallation, prepareFishInstallation } from "./fish.js";
 
 interface ShellInstallationInfo {
   shellName: string;
@@ -45,13 +46,6 @@ const shellInstallationInfo: Array<ShellInstallationInfo> = [
     commandToAddPath: "echo 'export PATH=\"$PATH:<TARGET>\"' >> ~/.zshrc",
   },
   {
-    shellName: "fish",
-    configFileName: ".config/fish/config.fish",
-    commandToAddComment:
-      "echo '' >> ~/.config/fish/config.fish && echo '# Added by LM Studio CLI tool (lms)' >> ~/.config/fish/config.fish",
-    commandToAddPath: "echo 'set -gx PATH $PATH <TARGET>' >> ~/.config/fish/config.fish",
-  },
-  {
     shellName: "csh",
     configFileName: ".cshrc",
     commandToAddComment:
@@ -69,7 +63,9 @@ const shellInstallationInfo: Array<ShellInstallationInfo> = [
 
 export async function installCliDarwinOrLinux(path: string, { skipConfirmation }: InstallCliOpts) {
   const detectedShells: Array<ShellInstallationInfo> = [];
-  const detectedAlreadyInstalledShells: Array<ShellInstallationInfo> = [];
+  const detectedAlreadyInstalledShells: Array<
+    Pick<ShellInstallationInfo, "shellName" | "configFileName">
+  > = [];
   for (const shell of shellInstallationInfo) {
     const configPath = join(os.homedir(), shell.configFileName);
     try {
@@ -85,7 +81,15 @@ export async function installCliDarwinOrLinux(path: string, { skipConfirmation }
     }
   }
 
-  if (detectedShells.length === 0) {
+  const fishInstallation = await prepareFishInstallation(path);
+  if (fishInstallation?.updates.length === 0) {
+    detectedAlreadyInstalledShells.push({
+      shellName: "fish",
+      configFileName: fishInstallation.configPath,
+    });
+  }
+
+  if (detectedShells.length === 0 && !fishInstallation?.updates.length) {
     if (detectedAlreadyInstalledShells.length === 0) {
       throw makeTitledPrettyError(
         "Unable to find any shell configuration files",
@@ -106,11 +110,12 @@ export async function installCliDarwinOrLinux(path: string, { skipConfirmation }
           LM Studio CLI tool is already installed for the following shells:
 
           ${detectedAlreadyInstalledShells
-            .map(shell =>
-              chalk.cyanBright(
-                `    · ${shell.shellName} ${chalk.gray(`(~/${shell.configFileName})`)}`,
-              ),
-            )
+            .map(shell => {
+              const configPath = isAbsolute(shell.configFileName)
+                ? shell.configFileName
+                : `~/${shell.configFileName}`;
+              return chalk.cyanBright(`    · ${shell.shellName} ${chalk.gray(`(${configPath})`)}`);
+            })
             .join("\n")}
 
           If your shell is not listed above, please try to add the following directory to the PATH
@@ -137,11 +142,14 @@ export async function installCliDarwinOrLinux(path: string, { skipConfirmation }
     commandsToRun.push(command);
     commandsToRunFormatted.push(`    ${command} ${chalk.gray(`# for ${shell.shellName}`)}`);
   }
+  for (const update of fishInstallation?.updates ?? []) {
+    commandsToRunFormatted.push(`    Update ${update.path} ${chalk.gray("# for fish")}`);
+  }
 
   if (!skipConfirmation) {
     console.info(
       text`
-        We are about to run the following commands to install the LM Studio CLI tool
+        We are about to make the following changes to install the LM Studio CLI tool
         (lms).
 
         ${chalk.cyanBright(commandsToRunFormatted.join("\n"))}
@@ -167,7 +175,13 @@ export async function installCliDarwinOrLinux(path: string, { skipConfirmation }
     }
   }
 
-  execSync(commandsToRun.join(" && "));
+  if (commandsToRun.length > 0) {
+    execSync(commandsToRun.join(" && "));
+  }
+  if (fishInstallation) {
+    await applyFishInstallation(fishInstallation);
+    console.info(`Fish configuration: ${fishInstallation.configPath}`);
+  }
 
   console.info(
     text`

--- a/packages/lms-lmstudio/src/installCli/fish.test.ts
+++ b/packages/lms-lmstudio/src/installCli/fish.test.ts
@@ -1,0 +1,289 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, stat, utimes, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { dirname, join } from "node:path";
+import { applyFishInstallation, prepareFishInstallation } from "./fish.js";
+
+let fixtureDir: string;
+let targetPath: string;
+let configPath: string;
+let snippetPath: string;
+
+async function write(path: string, content: string) {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+async function prepare() {
+  const installation = await prepareFishInstallation(targetPath);
+  expect(installation).not.toBeNull();
+  return installation!;
+}
+
+const legacyBlock = (target: string) =>
+  `# Added by LM Studio CLI tool (lms)\nset -gx PATH $PATH ${target}\n`;
+
+beforeEach(async () => {
+  fixtureDir = await mkdtemp(join(os.tmpdir(), "lms-fish-test-"));
+  targetPath = join(fixtureDir, ".lmstudio", "bin");
+  configPath = join(fixtureDir, ".config", "fish", "config.fish");
+  snippetPath = join(fixtureDir, ".config", "fish", "conf.d", "lms.fish");
+  jest.spyOn(os, "homedir").mockReturnValue(fixtureDir);
+  jest.replaceProperty(process, "env", { ...process.env, SHELL: "/bin/zsh", XDG_CONFIG_HOME: "" });
+});
+
+afterEach(async () => {
+  jest.restoreAllMocks();
+  await rm(fixtureDir, { recursive: true, force: true });
+});
+
+describe("fish installation", () => {
+  test("does not install fish without an existing configuration directory or fish login shell", async () => {
+    expect(await prepareFishInstallation(targetPath)).toBeNull();
+  });
+
+  test("supports a conf.d-only setup without creating config.fish", async () => {
+    await mkdir(dirname(snippetPath), { recursive: true });
+    const installation = await prepare();
+    await expect(stat(snippetPath)).rejects.toMatchObject({ code: "ENOENT" });
+    await applyFishInstallation(installation);
+    expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path --append --path");
+    await expect(stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("creates conf.d for a fish login shell with no existing configuration", async () => {
+    process.env.SHELL = "/opt/homebrew/bin/fish";
+    await applyFishInstallation(await prepare());
+    expect(await readFile(snippetPath, "utf8")).toContain(targetPath);
+    await expect(stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("reinstalling does not rewrite the snippet or change custom config.fish contents", async () => {
+    const customConfig = "# Personal configuration\nset -g fish_greeting\n";
+    await write(configPath, customConfig);
+    await applyFishInstallation(await prepare());
+    const original = await readFile(snippetPath, "utf8");
+    const timestamp = new Date("2000-01-01T00:00:00Z");
+    await utimes(snippetPath, timestamp, timestamp);
+    await applyFishInstallation(await prepare());
+    expect(await readFile(snippetPath, "utf8")).toBe(original);
+    expect((await stat(snippetPath)).mtime).toEqual(timestamp);
+    expect(await readFile(configPath, "utf8")).toBe(customConfig);
+  });
+
+  test("removes repeated legacy blocks while preserving unmarked and user-modified commands", async () => {
+    const custom = `# Personal configuration\nset -gx PATH $PATH ${targetPath}\n`;
+    const modified = "# Added by LM Studio CLI tool (lms)\nset -gx PATH /custom $PATH\n";
+    await write(configPath, custom + legacyBlock(targetPath) + modified + legacyBlock(targetPath));
+    await applyFishInstallation(await prepare());
+    expect(await readFile(configPath, "utf8")).toBe(custom + modified);
+    expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path --append --path");
+  });
+
+  test.each([
+    "~/.lmstudio/bin",
+    "$HOME/.lmstudio/bin",
+    '"$HOME/.lmstudio/bin"',
+    "absolute",
+    "single-quoted",
+    "double-quoted",
+  ])("migrates a recognized legacy block with a %s target", async spelling => {
+    const target =
+      spelling === "absolute"
+        ? targetPath
+        : spelling === "single-quoted"
+          ? `'${targetPath}'`
+          : spelling === "double-quoted"
+            ? `"${targetPath}"`
+            : spelling;
+    await write(configPath, legacyBlock(target));
+    await applyFishInstallation(await prepare());
+    expect(await readFile(configPath, "utf8")).toBe("");
+  });
+
+  test("preserves CRLF in surrounding configuration", async () => {
+    await write(
+      configPath,
+      "# before\r\n" + legacyBlock(targetPath).replaceAll("\n", "\r\n") + "# after\r\n",
+    );
+    await applyFishInstallation(await prepare());
+    expect(await readFile(configPath, "utf8")).toBe("# before\r\n# after\r\n");
+  });
+
+  test("reuses a corrected block in lms.fish and preserves custom functions", async () => {
+    const helpers = "function lmsup\n    lms server start\nend\n\n";
+    await write(
+      snippetPath,
+      helpers +
+        '# Added by LM Studio CLI (lms)\nfish_add_path "$HOME/.lmstudio/bin"\n# End of LM Studio CLI section\n',
+    );
+    await applyFishInstallation(await prepare());
+    const snippet = await readFile(snippetPath, "utf8");
+    expect(snippet.startsWith(helpers)).toBe(true);
+    expect(snippet).not.toContain("# Added by LM Studio CLI (lms)");
+    expect(snippet.match(/fish_add_path --append --path/g)).toHaveLength(1);
+    await expect(stat(configPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test("appends to a custom snippet without a final newline", async () => {
+    await write(snippetPath, "# My helpers");
+    await applyFishInstallation(await prepare());
+    expect(await readFile(snippetPath, "utf8")).toMatch(/^# My helpers\n# >>> LM Studio CLI/);
+  });
+
+  test("updates a managed target and preserves content following the block", async () => {
+    process.env.SHELL = "/usr/bin/fish";
+    await applyFishInstallation(await prepare());
+    await write(snippetPath, (await readFile(snippetPath, "utf8")) + "# custom footer\n");
+    const oldTarget = targetPath;
+    targetPath = join(fixtureDir, "custom models", "bin");
+    await applyFishInstallation(await prepare());
+    const snippet = await readFile(snippetPath, "utf8");
+    expect(snippet).not.toContain(oldTarget);
+    expect(snippet).toContain(targetPath);
+    expect(snippet.endsWith("# custom footer\n")).toBe(true);
+  });
+
+  test("a comment mentioning the target does not suppress installation", async () => {
+    await write(configPath, `# ${targetPath}\n`);
+    await applyFishInstallation(await prepare());
+    expect(await readFile(snippetPath, "utf8")).toContain("fish_add_path --append --path");
+    expect(await readFile(configPath, "utf8")).toBe(`# ${targetPath}\n`);
+  });
+
+  test("respects XDG_CONFIG_HOME and migrates both the active and old hardcoded config paths", async () => {
+    process.env.XDG_CONFIG_HOME = join(fixtureDir, "custom config");
+    const activeConfig = join(process.env.XDG_CONFIG_HOME, "fish", "config.fish");
+    await write(activeConfig, "# active\n" + legacyBlock(targetPath));
+    await write(configPath, "# default\n" + legacyBlock(targetPath));
+    const installation = await prepare();
+    expect(installation.configPath).toBe(
+      join(process.env.XDG_CONFIG_HOME, "fish", "conf.d", "lms.fish"),
+    );
+    await applyFishInstallation(installation);
+    expect(await readFile(activeConfig, "utf8")).toBe("# active\n");
+    expect(await readFile(configPath, "utf8")).toBe("# default\n");
+    await expect(stat(snippetPath)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  test.each([undefined, "", "relative/config"])(
+    "uses ~/.config for XDG_CONFIG_HOME=%s",
+    async value => {
+      if (value === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = value;
+      }
+      process.env.SHELL = "/usr/bin/fish";
+      expect((await prepare()).configPath).toBe(snippetPath);
+    },
+  );
+
+  test("does not remove legacy configuration if the snippet cannot be written", async () => {
+    const legacy = legacyBlock(targetPath);
+    await write(configPath, legacy);
+    const installation = await prepare();
+    await mkdir(snippetPath, { recursive: true });
+    await expect(applyFishInstallation(installation)).rejects.toMatchObject({ code: "EISDIR" });
+    expect(await readFile(configPath, "utf8")).toBe(legacy);
+  });
+
+  test.each([
+    "# >>> LM Studio CLI (lms) >>>\n# user text\n",
+    "# >>> LM Studio CLI (lms) >>>\n# >>> LM Studio CLI (lms) >>>\n# user text\n# <<< LM Studio CLI (lms) <<<\n",
+  ])("preserves malformed managed blocks and reports the problem", async incomplete => {
+    await write(snippetPath, incomplete);
+    await expect(prepareFishInstallation(targetPath)).rejects.toThrow(
+      "Incomplete LM Studio CLI block",
+    );
+    expect(await readFile(snippetPath, "utf8")).toBe(incomplete);
+  });
+});
+
+const fishAvailable = spawnSync("fish", ["--version"]).status === 0;
+const describeWithFish = fishAvailable ? describe : describe.skip;
+
+describeWithFish("generated snippet in fish", () => {
+  function runFish(command: string, ...args: Array<string>) {
+    return execFileSync("fish", ["--no-config", "--command", command, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        XDG_CONFIG_HOME: join(fixtureDir, ".config"),
+        XDG_DATA_HOME: join(fixtureDir, "data"),
+        XDG_CACHE_HOME: join(fixtureDir, "cache"),
+      },
+    }).trim();
+  }
+
+  beforeEach(async () => {
+    process.env.SHELL = "/usr/bin/fish";
+    targetPath = join(fixtureDir, "model tools' $literal (test) \\folder", "bin");
+    await mkdir(targetPath, { recursive: true });
+    await applyFishInstallation(await prepare());
+  });
+
+  test.each([false, true])(
+    "does not duplicate PATH on repeated sourcing (compatibility fallback: %s)",
+    fallback => {
+      const disableFishAddPath = fallback
+        ? "set -g fish_function_path; functions -e fish_add_path"
+        : "";
+      const result = runFish(
+        `set -g fish_user_paths
+set -gx PATH /usr/bin /bin
+${disableFishAddPath}
+for run in 1 2 3
+    source $argv[1]
+    count (string match -- $argv[2] $PATH)
+end
+printf '%s\\n' $PATH`,
+        snippetPath,
+        targetPath,
+      );
+      expect(result).toBe(`1\n1\n1\n/usr/bin\n/bin\n${targetPath}`);
+    },
+  );
+
+  test("keeps one PATH entry in nested fish", () => {
+    expect(
+      runFish(
+        `set -g fish_user_paths
+set -gx PATH /usr/bin /bin
+source $argv[1]
+set -l fish_executable (status fish-path)
+$fish_executable --no-config --command 'source $argv[1]; count (string match -- $argv[2] $PATH)' $argv[1] $argv[2]`,
+        snippetPath,
+        targetPath,
+      ),
+    ).toBe("1");
+  });
+
+  test("does not set a universal fish_user_paths variable", () => {
+    expect(
+      runFish(
+        "source $argv[1]; set --query --universal fish_user_paths; echo $status",
+        snippetPath,
+      ),
+    ).toBe("1");
+  });
+
+  test("fish automatically loads the snippet at startup", () => {
+    const fishExecutable = runFish("status fish-path");
+    expect(
+      execFileSync(
+        fishExecutable,
+        ["--command", "count (string match -- $argv[1] $PATH)", targetPath],
+        {
+          encoding: "utf8",
+          env: {
+            PATH: "/usr/bin:/bin",
+            XDG_CONFIG_HOME: join(fixtureDir, ".config"),
+            XDG_DATA_HOME: join(fixtureDir, "data"),
+            XDG_CACHE_HOME: join(fixtureDir, "cache"),
+          },
+        },
+      ).trim(),
+    ).toBe("1");
+  });
+});

--- a/packages/lms-lmstudio/src/installCli/fish.ts
+++ b/packages/lms-lmstudio/src/installCli/fish.ts
@@ -1,0 +1,164 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import os from "node:os";
+import { basename, dirname, isAbsolute, join, relative } from "node:path";
+
+const blockStart = "# >>> LM Studio CLI (lms) >>>";
+const blockEnd = "# <<< LM Studio CLI (lms) <<<";
+
+interface FileUpdate {
+  path: string;
+  content: string;
+}
+
+export interface FishInstallation {
+  configPath: string;
+  updates: Array<FileUpdate>;
+}
+
+function isMissingFile(error: unknown) {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function readConfig(path: string) {
+  try {
+    return await readFile(path, "utf8");
+  } catch (error) {
+    if (isMissingFile(error)) {
+      return "";
+    }
+    throw error;
+  }
+}
+
+function quoteFish(value: string) {
+  return `'${value.replaceAll("\\", "\\\\").replaceAll("'", "\\'")}'`;
+}
+
+function makeBlock(targetPath: string) {
+  const target = quoteFish(targetPath);
+  return `${blockStart}
+if functions -q fish_add_path
+    fish_add_path --append --path ${target}
+else if not contains -- ${target} $PATH
+    set -gx PATH $PATH ${target}
+end
+${blockEnd}
+`;
+}
+
+function removeLegacyBlocks(content: string, targetPath: string) {
+  const doubleQuote = (value: string) =>
+    `"${value.replace(/[\\"$]/g, character => `\\${character}`)}"`;
+  const targets = [targetPath, quoteFish(targetPath), doubleQuote(targetPath)];
+  const relativeTarget = relative(os.homedir(), targetPath);
+  if (relativeTarget !== ".." && !relativeTarget.startsWith("../") && !isAbsolute(relativeTarget)) {
+    targets.push(`"$HOME/${doubleQuote(relativeTarget).slice(1, -1)}"`);
+    if (/^[\w./-]+$/.test(relativeTarget)) {
+      targets.push(`~/${relativeTarget}`, `$HOME/${relativeTarget}`);
+    }
+  }
+  const commands = new Set(
+    targets.flatMap(target => [
+      `set -gx PATH $PATH ${target}`,
+      `fish_add_path ${target}`,
+      `fish_add_path --append --path ${target}`,
+    ]),
+  );
+  const markers = new Set([
+    "# Added by LM Studio CLI tool (lms)",
+    "# Added by LM Studio CLI (lms)",
+  ]);
+  const endMarkers = new Set([
+    "# End of LM Studio CLI section",
+    "# End of LM Studio CLI tool (lms)",
+  ]);
+  // Keep original line endings and all text outside recognized marker/command pairs.
+  const lines = content.match(/[^\n]*\n|[^\n]+$/g) ?? [];
+  const lineText = (index: number) => lines[index]?.replace(/\r?\n$/, "") ?? "";
+  const kept: Array<string> = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (markers.has(lineText(i)) && commands.has(lineText(i + 1))) {
+      i++;
+      if (endMarkers.has(lineText(i + 1))) {
+        i++;
+      }
+    } else {
+      kept.push(lines[i]);
+    }
+  }
+  return kept.join("");
+}
+
+function updateManagedBlock(content: string, block: string) {
+  const blockPattern =
+    /^# >>> LM Studio CLI \(lms\) >>>\r?\n[\s\S]*?^# <<< LM Studio CLI \(lms\) <<<(?:\r?\n|$)/gm;
+  const markers = content.match(
+    /^# (?:>>> LM Studio CLI \(lms\) >>>|<<< LM Studio CLI \(lms\) <<<)\r?$/gm,
+  );
+  if ((markers?.length ?? 0) !== [...content.matchAll(blockPattern)].length * 2) {
+    throw new Error(
+      "Incomplete LM Studio CLI block in fish/conf.d/lms.fish. Please repair it before installing.",
+    );
+  }
+  let replaced = false;
+  const updated = content.replace(blockPattern, () => {
+    if (replaced) {
+      return "";
+    }
+    replaced = true;
+    return block;
+  });
+  return replaced ? updated : content + (content && !content.endsWith("\n") ? "\n" : "") + block;
+}
+
+/** Plan the fish changes without writing anything before the installer confirmation. */
+export async function prepareFishInstallation(
+  targetPath: string,
+): Promise<FishInstallation | null> {
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  const configRoot =
+    xdgConfigHome && isAbsolute(xdgConfigHome) ? xdgConfigHome : join(os.homedir(), ".config");
+  const fishDir = join(configRoot, "fish");
+  const fishDirStat = await stat(fishDir).catch(error => {
+    if (isMissingFile(error)) {
+      return null;
+    }
+    throw error;
+  });
+  if (!fishDirStat?.isDirectory() && basename(process.env.SHELL ?? "") !== "fish") {
+    return null;
+  }
+
+  const configPath = join(fishDir, "conf.d", "lms.fish");
+  const previousSnippet = await readConfig(configPath);
+  const snippet = updateManagedBlock(
+    removeLegacyBlocks(previousSnippet, targetPath),
+    makeBlock(targetPath),
+  );
+  const updates: Array<FileUpdate> = [];
+  if (snippet !== previousSnippet) {
+    updates.push({ path: configPath, content: snippet });
+  }
+
+  // Older installers always wrote ~/.config, even when fish used XDG_CONFIG_HOME.
+  const legacyPaths = new Set([
+    join(fishDir, "config.fish"),
+    join(os.homedir(), ".config", "fish", "config.fish"),
+  ]);
+  for (const path of legacyPaths) {
+    const previous = await readConfig(path);
+    const content = removeLegacyBlocks(previous, targetPath);
+    if (content !== previous) {
+      updates.push({ path, content });
+    }
+  }
+  return { configPath, updates };
+}
+
+export async function applyFishInstallation(installation: FishInstallation) {
+  // Install the replacement before removing legacy lines from config.fish.
+  for (const update of installation.updates) {
+    await mkdir(dirname(update.path), { recursive: true });
+    await writeFile(update.path, update.content, "utf8");
+  }
+}


### PR DESCRIPTION
Fixes #639.

Moves fish PATH setup from `config.fish` to `conf.d/lms.fish` and respects `XDG_CONFIG_HOME`. Uses `fish_add_path` to avoid duplicate entries, with a guarded fallback for older fish.

Migrates recognized old LM Studio blocks and preserves custom config, including existing content in `lms.fish`. Adds tests for installation, reruns, migration and fish startup.

Tested on macOS with fish 4.9.1 and Node 25.5.0. Build passes; 523 tests pass, including 34 new installer tests.

Related: lmstudio-ai/lmstudio-bug-tracker#656, lmstudio-ai/lms#232, lmstudio-ai/lms#5. The desktop's automatic repeated-write bug was fixed separately; this addresses explicit bootstrap and the generated fish setup.

Overlaps with #582 in `darwinOrLinux.ts` and its test file.
